### PR TITLE
[Fix] update required mmcv version to `>=1.3.13`

### DIFF
--- a/requirements/mminstall.txt
+++ b/requirements/mminstall.txt
@@ -1,2 +1,2 @@
 mmcls
-mmcv-full>=1.3.8,<=1.5.0
+mmcv-full>=1.3.13,<=1.5.0


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

The `revert_sync_batchnorm ` used in `DetNAS` is a new feature in `mmcv=1.3.13`, so we need update required mmcv version(#20)

## Modification
`requirements/mminstall.txt`
update required mmcv version from `mmcv>=1.3.8,<=1.50` to `mmcv>1.3.13,<=1.50`

## BC-breaking (Optional)

No

## Use cases (Optional)

No

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
