### PR TITLE
[Fix] Fix symlink error on windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,7 +112,7 @@ venv.bak/
 *.pkl.json
 *.log.json
 /work_dirs
-/mmcls/.mim
+/mmrazor/.mim
 
 # Pytorch
 *.pth

--- a/setup.py
+++ b/setup.py
@@ -131,7 +131,19 @@ def add_mim_extension():
 
             if mode == 'symlink':
                 src_relpath = osp.relpath(src_path, osp.dirname(tar_path))
-                os.symlink(src_relpath, tar_path)
+                try:
+                    os.symlink(src_relpath, tar_path)
+                except OSError:
+                    # Creating a symbolic link on windows may raise an
+                    # `OSError: [WinError 1314]` due to privilege. If
+                    # the error happens, the src file will be copied
+                    mode = 'copy'
+                    warnings.warn(
+                        f'Failed to create a symbolic link for {src_relpath}, '
+                        f'and it will be copied to {tar_path}')
+                else:
+                    continue
+
             elif mode == 'copy':
                 if osp.isfile(src_path):
                     shutil.copyfile(src_path, tar_path)


### PR DESCRIPTION
## Motivation

Use copy instead of symlink on windows to prevent `OSError: [WinError 1314]`.

Related issue: [open-mmlab/mmrazor#40](https://github.com/open-mmlab/mmrazor/issues/40).

## Modification

`setup.py` & `.gitignore`.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
