### PR TITLE
[Docs] Add OpenMMLab website and platform links and mmdeploy link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,22 @@
 <div align="center">
   <img src="resources/mmrazor-logo.png" width="600"/>
+  <div>&nbsp;</div>
+  <div align="center">
+    <b><font size="5">OpenMMLab website</font></b>
+    <sup>
+      <a href="https://openmmlab.com">
+        <i><font size="4">HOT</font></i>
+      </a>
+    </sup>
+    &nbsp;&nbsp;&nbsp;&nbsp;
+    <b><font size="5">OpenMMLab platform</font></b>
+    <sup>
+      <a href="https://platform.openmmlab.com">
+        <i><font size="4">TRY IT OUT</font></i>
+      </a>
+    </sup>
+  </div>
+  <div>&nbsp;</div>
 </div>
 <br />
 
@@ -116,3 +133,4 @@ We wish that the toolbox and benchmark could serve the growing research communit
 - [MMHuman3D](https://github.com/open-mmlab/mmhuman3d): OpenMMLab 3D Human Parametric Model Toolbox and Benchmark.
 - [MMSelfSup](https://github.com/open-mmlab/mmselfsup): OpenMMLab self-supervised learning Toolbox and Benchmark.
 - [MMRazor](https://github.com/open-mmlab/mmrazor): OpenMMLab Model Compression Toolbox and Benchmark.
+- [MMDeploy](https://github.com/open-mmlab/mmdeploy): OpenMMLab Model Deployment Framework.

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -1,5 +1,22 @@
 <div align="center">
   <img src="resources/mmrazor-logo.png" width="600"/>
+  <div>&nbsp;</div>
+  <div align="center">
+    <b><font size="5">OpenMMLab 官网</font></b>
+    <sup>
+      <a href="https://openmmlab.com">
+        <i><font size="4">HOT</font></i>
+      </a>
+    </sup>
+    &nbsp;&nbsp;&nbsp;&nbsp;
+    <b><font size="5">OpenMMLab 开放平台</font></b>
+    <sup>
+      <a href="https://platform.openmmlab.com">
+        <i><font size="4">TRY IT OUT</font></i>
+      </a>
+    </sup>
+  </div>
+  <div>&nbsp;</div>
 </div>
 <br />
 
@@ -141,6 +158,8 @@ MMRazor 是一款由来自不同高校和企业的研发人员共同参与贡献
 - [MMHuman3D](https://github.com/open-mmlab/mmhuman3d): OpenMMLab 人体参数化模型工具箱与测试基准
 - [MMSelfSup](https://github.com/open-mmlab/mmselfsup): OpenMMLab 自监督学习工具箱与测试基准
 - [MMRazor](https://github.com/open-mmlab/mmrazor): OpenMMLab 模型压缩工具箱与测试基准
+- [MMDeploy](https://github.com/open-mmlab/mmdeploy): OpenMMLab 模型部署框架
+
 ## 欢迎加入 OpenMMLab 社区
 
 扫描下方的二维码可关注 OpenMMLab 团队的 [知乎官方账号](https://www.zhihu.com/people/openmmlab)，加入 OpenMMLab 团队的 [官方交流 QQ 群](https://jq.qq.com/?_wv=1027&k=aCvMxdr3)

--- a/tools/mmcls/search_mmcls.py
+++ b/tools/mmcls/search_mmcls.py
@@ -124,14 +124,16 @@ def main():
         shuffle=False,
         round_up=True)
 
-    # build the model and load checkpoint
-    model = build_algorithm(cfg.algorithm)
+    # build the algorithm and load checkpoint
+    algorithm = build_algorithm(cfg.algorithm)
+    model = algorithm.architecture.model
 
     fp16_cfg = cfg.get('fp16', None)
     if fp16_cfg is not None:
         wrap_fp16_model(model)
 
-    checkpoint = load_checkpoint(model, args.checkpoint, map_location='cpu')
+    checkpoint = load_checkpoint(
+        algorithm, args.checkpoint, map_location='cpu')
 
     if 'CLASSES' in checkpoint.get('meta', {}):
         CLASSES = checkpoint['meta']['CLASSES']
@@ -144,15 +146,15 @@ def main():
 
     if not distributed:
         if args.device == 'cpu':
-            model = model.cpu()
+            algorithm = algorithm.cpu()
         else:
-            model = MMDataParallel(model, device_ids=[0])
+            algorithm = MMDataParallel(algorithm, device_ids=[0])
         model.CLASSES = CLASSES
         test_fn = single_gpu_test
 
     else:
-        model = MMDistributedDataParallel(
-            model.cuda(),
+        algorithm = MMDistributedDataParallel(
+            algorithm.cuda(),
             device_ids=[torch.cuda.current_device()],
             broadcast_buffers=False)
         test_fn = multi_gpu_test
@@ -161,7 +163,7 @@ def main():
     searcher = build_searcher(
         cfg.searcher,
         default_args=dict(
-            algorithm=model,
+            algorithm=algorithm,
             dataloader=data_loader,
             test_fn=test_fn,
             work_dir=cfg.work_dir,

--- a/tools/mmdet/search_mmdet.py
+++ b/tools/mmdet/search_mmdet.py
@@ -154,6 +154,7 @@ def main():
     model_cfg.train_cfg = None
     algorithm = build_algorithm(cfg.algorithm)
     model = algorithm.architecture.model
+
     fp16_cfg = cfg.get('fp16', None)
     if fp16_cfg is not None:
         wrap_fp16_model(model)

--- a/tools/mmdet/test_mmdet.py
+++ b/tools/mmdet/test_mmdet.py
@@ -171,13 +171,16 @@ def main():
         dist=distributed,
         shuffle=False)
 
-    # build the model and load checkpoint
+    # build the algorithm and load checkpoint
     cfg.algorithm.architecture.model.train_cfg = None
-    model = build_algorithm(cfg.algorithm)
+    algorithm = build_algorithm(cfg.algorithm)
+    model = algorithm.architecture.model
+
     fp16_cfg = cfg.get('fp16', None)
     if fp16_cfg is not None:
         wrap_fp16_model(model)
-    checkpoint = load_checkpoint(model, args.checkpoint, map_location='cpu')
+    checkpoint = load_checkpoint(
+        algorithm, args.checkpoint, map_location='cpu')
     if args.fuse_conv_bn:
         model = fuse_conv_bn(model)
     # old versions did not save class info in checkpoints, this walkaround is
@@ -188,15 +191,15 @@ def main():
         model.CLASSES = dataset.CLASSES
 
     if not distributed:
-        model = MMDataParallel(model, device_ids=[0])
-        outputs = single_gpu_test(model, data_loader, args.show, args.show_dir,
-                                  args.show_score_thr)
+        algorithm = MMDataParallel(algorithm, device_ids=[0])
+        outputs = single_gpu_test(algorithm, data_loader, args.show,
+                                  args.show_dir, args.show_score_thr)
     else:
-        model = MMDistributedDataParallel(
-            model.cuda(),
+        algorithm = MMDistributedDataParallel(
+            algorithm.cuda(),
             device_ids=[torch.cuda.current_device()],
             broadcast_buffers=False)
-        outputs = multi_gpu_test(model, data_loader, args.tmpdir,
+        outputs = multi_gpu_test(algorithm, data_loader, args.tmpdir,
                                  args.gpu_collect)
 
     rank, _ = get_dist_info()

--- a/tools/mmseg/test_mmseg.py
+++ b/tools/mmseg/test_mmseg.py
@@ -148,15 +148,17 @@ def main():
         dist=distributed,
         shuffle=False)
 
-    # build the model and load checkpoint
+    # build the algorithm and load checkpoint
     # Difference from mmsegmentation
     cfg.algorithm.architecture.model.train_cfg = None
-    model = build_algorithm(cfg.algorithm)
+    algorithm = build_algorithm(cfg.algorithm)
+    model = algorithm.architecture.model
 
     fp16_cfg = cfg.get('fp16', None)
     if fp16_cfg is not None:
         wrap_fp16_model(model)
-    checkpoint = load_checkpoint(model, args.checkpoint, map_location='cpu')
+    checkpoint = load_checkpoint(
+        algorithm, args.checkpoint, map_location='cpu')
     if 'CLASSES' in checkpoint.get('meta', {}):
         model.CLASSES = checkpoint['meta']['CLASSES']
     else:
@@ -197,9 +199,9 @@ def main():
         tmpdir = None
 
     if not distributed:
-        model = MMDataParallel(model, device_ids=[0])
+        algorithm = MMDataParallel(algorithm, device_ids=[0])
         results = single_gpu_test(
-            model,
+            algorithm,
             data_loader,
             args.show,
             args.show_dir,
@@ -209,12 +211,12 @@ def main():
             format_only=args.format_only or eval_on_format_results,
             format_args=eval_kwargs)
     else:
-        model = MMDistributedDataParallel(
-            model.cuda(),
+        algorithm = MMDistributedDataParallel(
+            algorithm.cuda(),
             device_ids=[torch.cuda.current_device()],
             broadcast_buffers=False)
         results = multi_gpu_test(
-            model,
+            algorithm,
             data_loader,
             args.tmpdir,
             args.gpu_collect,


### PR DESCRIPTION
## Motivation

Since OpenMMLab's website and platform is open to the public, we hope that the users in GitHub could visit our new website and platform. This will help the people interested in OpenMMLab to experience our algorithms and models visually, and learn more about our codebases.

## Modification

Add OpenMMLab's website and platform links and mmdeploy link in `README.md` and `README_zh-CN.md`.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
