### PR TITLE
[Refactor]Deprecate the support for ``python setup.py test``

### DIFF
--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,4 +1,4 @@
-albumentations>=0.3.2 --no-binary imgaug,albumentations
+albumentations>=0.3.2
 mmdet
 mmsegmentation
 timm

--- a/setup.py
+++ b/setup.py
@@ -163,10 +163,7 @@ if __name__ == '__main__':
         description='OpenMMLab Model Compression Toolbox and Benchmark',
         long_description=readme(),
         long_description_content_type='text/markdown',
-        author='MMRazor Contributors',
-        author_email='openmmlab@gmail.com',
         keywords='computer vision, model compression',
-        url='https://github.com/open-mmlab/mmrazor',
         packages=find_packages(exclude=('configs', 'tools', 'demo')),
         include_package_data=True,
         classifiers=[
@@ -179,8 +176,16 @@ if __name__ == '__main__':
             'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
+            'Topic :: Scientific/Engineering :: Artificial Intelligence',
         ],
+        url='https://github.com/open-mmlab/mmrazor',
+        author='MMRazor Contributors',
+        author_email='openmmlab@gmail.com',
         license='Apache License 2.0',
-        tests_require=parse_requirements('requirements/tests.txt'),
         install_requires=parse_requirements('requirements/runtime.txt'),
+        extras_require={
+            'all': parse_requirements('requirements.txt'),
+            'tests': parse_requirements('requirements/tests.txt'),
+            'optional': parse_requirements('requirements/optional.txt'),
+        },
         zip_safe=False)


### PR DESCRIPTION
## Motivation

Refers to https://github.com/open-mmlab/mmcv/pull/1637

## Modification

Update the setup.py

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
