### PR TITLE
[Feature] Support CPU training

### DIFF
--- a/mmrazor/apis/mmdet/train.py
+++ b/mmrazor/apis/mmdet/train.py
@@ -42,7 +42,6 @@ def train_detector(model,
                    distributed=False,
                    validate=False,
                    timestamp=None,
-                   device='cuda',
                    meta=None):
     """Copy from mmdetection and modify some codes.
 
@@ -103,13 +102,7 @@ def train_detector(model,
                 broadcast_buffers=False,
                 find_unused_parameters=find_unused_parameters)
     else:
-        if device == 'cuda':
-            model = MMDataParallel(
-                model.cuda(cfg.gpu_ids[0]), device_ids=cfg.gpu_ids)
-        elif device == 'cpu':
-            model = model.cpu()
-        else:
-            raise ValueError(F'unsupported device name {device}.')
+        model = MMDataParallel(model, device_ids=cfg.gpu_ids)
 
     # build optimizers
     # Difference from mmdetection.

--- a/mmrazor/apis/mmseg/train.py
+++ b/mmrazor/apis/mmseg/train.py
@@ -85,8 +85,7 @@ def train_segmentor(model,
                 broadcast_buffers=False,
                 find_unused_parameters=find_unused_parameters)
     else:
-        model = MMDataParallel(
-            model.cuda(cfg.gpu_ids[0]), device_ids=cfg.gpu_ids)
+        model = MMDataParallel(model, device_ids=cfg.gpu_ids)
 
     # build optimizers
     # Difference from mmdetection.


### PR DESCRIPTION
Hi! Related to [open-mmlab/mmdet#7016](https://github.com/open-mmlab/mmdetection/pull/7016), CPU training in MMRazor is supported in this pr. 

We modified the train api in ``mmrazor/apis/mmdet(mmseg)/train.py`` while kept ``mmrazor/apis/mmcls/train.py`` the same.

Now we can use the CPU to train/debug our model and test our model with batch size >=2. Before running the program we need to export CUDA_VISIBLE_DEVICES=-1 to disable GPU visibility.