### PR TITLE
Update cwd loss

### DIFF
--- a/mmrazor/models/losses/cwd.py
+++ b/mmrazor/models/losses/cwd.py
@@ -2,7 +2,7 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-
+from mmseg.ops import resize
 from ..builder import LOSSES
 
 
@@ -38,6 +38,11 @@ class ChannelWiseDivergence(nn.Module):
         Return:
             torch.Tensor: The calculated loss value.
         """
+        preds_S = resize(
+            input=preds_S,
+            size=preds_T.shape[-2:],
+            mode='bilinear',
+            align_corners=True)
         assert preds_S.shape[-2:] == preds_T.shape[-2:]
         N, C, H, W = preds_S.shape
 


### PR DESCRIPTION
In the semantic segmentation task, even though the teacher model and the student model are trained in the same data set and have the same size of input, their outputs may be different. For example, the output of the student model is 16 times down sampling while the output of the teacher model is 8 times down sampling, which will lead to the loss cannot be calculated properly. We can resize the output of the student model to the output of the teacher model by adding the resize function in MMCV. Note that resize will not work when the output of the student model is the same as the output of the teacher model.