### PR TITLE
[CI] update pre-commit-config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,8 +25,8 @@ repos:
         args: ["--remove"]
       - id: mixed-line-ending
         args: ["--fix=lf"]
-  - repo: https://github.com/jumanjihouse/pre-commit-hooks
-    rev: 2.1.4
+  - repo: https://github.com/markdownlint/markdownlint
+    rev: v0.11.0
     hooks:
       - id: markdownlint
         args: ["-r", "~MD002,~MD013,~MD029,~MD033,~MD034",
@@ -40,11 +40,3 @@ repos:
     hooks:
       - id: docformatter
         args: ["--in-place", "--wrap-descriptions", "79"]
-  # - repo: local
-  #   hooks:
-  #     - id: clang-format
-  #       name: clang-format
-  #       description: Format files with ClangFormat
-  #       entry: clang-format -style=google -i
-  #       language: system
-  #       files: \.(c|cc|cxx|cpp|cu|h|hpp|hxx|cuh|proto)$


### PR DESCRIPTION
## Motivation

replace `markdownlint`'s mapping github refering to `mmdet`, it is more friendly for users to develop in local.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
