### PR TITLE
detach output from teacher

### DIFF
--- a/mmrazor/models/distillers/self_distiller.py
+++ b/mmrazor/models/distillers/self_distiller.py
@@ -68,7 +68,7 @@ class SelfDistiller(BaseDistiller):
             outputs (tuple): out of module
         """
         if self.training and getattr(self, 'is_teacher', None):
-            self.teacher_outputs[self.module2name[module]].append(outputs)
+            self.teacher_outputs[self.module2name[module]].append(outputs.detach())
 
     def student_forward_output_hook(self, module, inputs, outputs):
         """Save the output.


### PR DESCRIPTION
When using Self Distiller with Channel Wise Distill, there would be a backward exception due to the tensor from teacher is not detached.

The PR fixed this bug.