### PR TITLE
[Fix] Fix module wrappers registry

### DIFF
--- a/mmrazor/core/distributed_wrapper.py
+++ b/mmrazor/core/distributed_wrapper.py
@@ -1,9 +1,13 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import torch
 import torch.nn as nn
-from mmcv.parallel import MODULE_WRAPPERS, MMDistributedDataParallel
+from mmcv.parallel import MODULE_WRAPPERS as MMCV_MODULE_WRAPPERS
+from mmcv.parallel import MMDistributedDataParallel
 from mmcv.parallel.scatter_gather import scatter_kwargs
+from mmcv.utils import Registry
 from torch.cuda._utils import _get_device_index
+
+MODULE_WRAPPERS = Registry('module wrapper', parent=MMCV_MODULE_WRAPPERS)
 
 
 @MODULE_WRAPPERS.register_module()


### PR DESCRIPTION
## Motivation

Register `DistributedDataParallelWrapper`  to a separate registry whose parent is the MODULE_WRAPPERS registry in mmcv. This avoids scope collision with other codebases.

Refer pr: [open-mmlab/mmpose#1204](https://github.com/open-mmlab/mmpose/pull/1204)
Related issue pr: [open-mmlab/mmdeploy#220](https://github.com/open-mmlab/mmdeploy/pull/220)