### PR TITLE
[Feature] Add Recorder to improve Distiller

### DIFF
--- a/mmrazor/core/__init__.py
+++ b/mmrazor/core/__init__.py
@@ -1,10 +1,13 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from .builder import build_searcher
+from .builder import build_recorder, build_searcher
 from .distributed_wrapper import DistributedDataParallelWrapper
 from .hooks import *  # noqa: F401,F403
 from .optimizer import *  # noqa: F401,F403
+from .recorders import *  # noqa: F401,F403
 from .runners import *  # noqa: F401,F403
 from .searcher import *  # noqa: F401,F403
 from .utils import *  # noqa: F401,F403
 
-__all__ = ['DistributedDataParallelWrapper', 'build_searcher']
+__all__ = [
+    'DistributedDataParallelWrapper', 'build_searcher', 'build_recorder'
+]

--- a/mmrazor/core/builder.py
+++ b/mmrazor/core/builder.py
@@ -2,8 +2,14 @@
 from mmcv.utils import Registry, build_from_cfg
 
 SEARCHERS = Registry('search')
+RECORDERS = Registry('recorders')
 
 
 def build_searcher(cfg, default_args=None):
     """Build searcher."""
     return build_from_cfg(cfg, SEARCHERS, default_args=default_args)
+
+
+def build_recorder(cfg, default_args=None):
+    """Build recorder."""
+    return build_from_cfg(cfg, RECORDERS, default_args=default_args)

--- a/mmrazor/core/recorders/__init__.py
+++ b/mmrazor/core/recorders/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from .function_outputs_recorder import FunctionOutputsRecorder
+from .method_outputs_recorder import MethodOutputsRecorder
+from .module_inputs_recorder import ModuleInputsRecorder
+from .module_outputs_recorder import ModuleOutputsRecorder
+from .param_recorder import ParameterRecorder
+from .recorder_manager import RecorderManager
+
+__all__ = [
+    'FunctionOutputsRecorder', 'MethodOutputsRecorder',
+    'ModuleOutputsRecorder', 'ParameterRecorder', 'RecorderManager',
+    'ModuleInputsRecorder'
+]

--- a/mmrazor/core/recorders/base_recorder.py
+++ b/mmrazor/core/recorders/base_recorder.py
@@ -1,0 +1,92 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from abc import ABCMeta, abstractmethod
+from typing import Optional, Any, Dict, List
+from torch import nn
+
+class BaseRecorder(metaclass=ABCMeta):
+    """Base class for recorders. 
+    Recorder is a context manager used to record various intermediate results 
+    during the model forward. It can be used in distiller and can also be used 
+    to obtain some specific data for visual analysis.
+
+    In MMRazor, there will be different types of recorders to obtain different 
+    types of intermediate results. They can be used in combination with the
+    ``RecorderManager``.
+
+    Note:
+        The recorder will be lazily initialized in the ``RecorderManager`` by 
+        default. If you want to use the recorder without the 
+        ``RecorderManager``, you need to initialize it first.
+    """
+
+    def __init__(self):
+        # Control whether to record.
+        # The `recording` will be set to True when enter the context manager, 
+        # and will be reset to  False when exit the context manager.
+        self.recording = False
+        # A recorder will record multiple intermediate results of this type, 
+        # which are recorded in dictionary format according to the data source.
+        self.data_buffer: Dict(str, list) = dict()
+        # All recorders will lazy init in `RecorderManager`.
+        self.initialized = False
+
+    @abstractmethod
+    def prepare_from_model(self, model: Optional[nn.Module]=None) -> None:
+        """Make the intermediate results of the model can be record."""
+        pass
+
+    def initialize(self, model: Optional[nn.Module]=None) -> None:
+        """Init the recorder.
+        
+        Args:
+            model (nn.Module): The model which need to record intermediate 
+                results.
+        """
+        self.prepare_from_model(model)
+        self.initialized = True
+
+    def get_record_data(self, 
+                        source: str, 
+                        data_index: Optional[int] = None) -> Any:
+        """Get data from ``data_buffer``.
+        
+        Args:
+            source (str): The key of the data saved in ``data_buffer``.
+            data_index (int, optional):  The index of source data saved in 
+                ``data_buffer``.
+
+        Returns:
+            Any: The type of the return value is undefined, and different 
+                source data may have different types.
+        """
+        # self.data_buffer: Dict(str, List)
+        data: List(Any) = self.data_buffer[source]
+
+        if data_index is not None:
+            assert isinstance(data_index, int), 'data_index must be int.'
+            assert data_index < len(data), 'data_index is illegal.'
+            return data[data_index]
+        else:
+            return data
+
+    def reset_data_buffer(self) -> None:
+        """Clear data in data_buffer."""
+        for key in self.data_buffer.keys():
+            self.data_buffer[key] = list()
+
+    def __enter__(self):
+        """Enter the context manager."""
+        assert self.initialized, \
+            'The recorder will be initialized in the RecorderManager by \
+            default. If you want to use the recorder without the \
+            RecorderManager, you need to initialize it first.'
+        self.recording = True
+        self.reset_data_buffer()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Exit the context manager"""
+        self.recording = False
+
+
+
+

--- a/mmrazor/core/recorders/base_recorder.py
+++ b/mmrazor/core/recorders/base_recorder.py
@@ -1,62 +1,64 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from abc import ABCMeta, abstractmethod
-from typing import Optional, Any, Dict, List
+from typing import Any, Dict, List, Optional
+
 from torch import nn
 
-class BaseRecorder(metaclass=ABCMeta):
-    """Base class for recorders. 
-    Recorder is a context manager used to record various intermediate results 
-    during the model forward. It can be used in distiller and can also be used 
-    to obtain some specific data for visual analysis.
 
-    In MMRazor, there will be different types of recorders to obtain different 
+class BaseRecorder(metaclass=ABCMeta):
+    """Base class for recorders. Recorder is a context manager used to record
+    various intermediate results during the model forward. It can be used in
+    distiller and can also be used to obtain some specific data for visual
+    analysis.
+
+    In MMRazor, there will be different types of recorders to obtain different
     types of intermediate results. They can be used in combination with the
     ``RecorderManager``.
 
     Note:
-        The recorder will be lazily initialized in the ``RecorderManager`` by 
-        default. If you want to use the recorder without the 
+        The recorder will be lazily initialized in the ``RecorderManager`` by
+        default. If you want to use the recorder without the
         ``RecorderManager``, you need to initialize it first.
     """
 
     def __init__(self):
         # Control whether to record.
-        # The `recording` will be set to True when enter the context manager, 
+        # The `recording` will be set to True when enter the context manager,
         # and will be reset to  False when exit the context manager.
         self.recording = False
-        # A recorder will record multiple intermediate results of this type, 
+        # A recorder will record multiple intermediate results of this type,
         # which are recorded in dictionary format according to the data source.
         self.data_buffer: Dict(str, list) = dict()
         # All recorders will lazy init in `RecorderManager`.
         self.initialized = False
 
     @abstractmethod
-    def prepare_from_model(self, model: Optional[nn.Module]=None) -> None:
+    def prepare_from_model(self, model: Optional[nn.Module] = None) -> None:
         """Make the intermediate results of the model can be record."""
         pass
 
-    def initialize(self, model: Optional[nn.Module]=None) -> None:
+    def initialize(self, model: Optional[nn.Module] = None) -> None:
         """Init the recorder.
-        
+
         Args:
-            model (nn.Module): The model which need to record intermediate 
+            model (nn.Module): The model which need to record intermediate
                 results.
         """
         self.prepare_from_model(model)
         self.initialized = True
 
-    def get_record_data(self, 
-                        source: str, 
+    def get_record_data(self,
+                        source: str,
                         data_index: Optional[int] = None) -> Any:
         """Get data from ``data_buffer``.
-        
+
         Args:
             source (str): The key of the data saved in ``data_buffer``.
-            data_index (int, optional):  The index of source data saved in 
+            data_index (int, optional):  The index of source data saved in
                 ``data_buffer``.
 
         Returns:
-            Any: The type of the return value is undefined, and different 
+            Any: The type of the return value is undefined, and different
                 source data may have different types.
         """
         # self.data_buffer: Dict(str, List)
@@ -80,13 +82,10 @@ class BaseRecorder(metaclass=ABCMeta):
             'The recorder will be initialized in the RecorderManager by \
             default. If you want to use the recorder without the \
             RecorderManager, you need to initialize it first.'
+
         self.recording = True
         self.reset_data_buffer()
 
     def __exit__(self, exc_type, exc_value, traceback):
-        """Exit the context manager"""
+        """Exit the context manager."""
         self.recording = False
-
-
-
-

--- a/mmrazor/core/recorders/function_outputs_recorder.py
+++ b/mmrazor/core/recorders/function_outputs_recorder.py
@@ -1,0 +1,100 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import functools
+from types import FunctionType
+from typing import List, Optional
+
+from mmcv.utils import import_modules_from_strings
+from torch import nn
+
+from ..builder import RECORDERS
+from .base_recorder import BaseRecorder
+
+
+@RECORDERS.register_module()
+class FunctionOutputsRecorder(BaseRecorder):
+    """Recorder for intermediate results which are ``FunctionType``'s outputs.
+
+    Args:
+        sources (List(str)): The names of the functions whose output
+            needs  to be recorded.
+        import_modules (List(str)): The modules which source
+            functions belong to.
+
+    TODO the example is not suitable enough.
+    Examples:
+        >>> import copy
+        >>> import torch
+        >>> from mmcv.cnn import ConvModule
+        >>> from mmrazor.core import build_recorder
+
+        >>> # example recorder config
+        >>> recorder_cfg = dict(
+        >>>     type='FunctionOutputs',
+        >>>     sources=['build_conv_layer'],
+        >>>     import_modules=['mmcv.cnn.bricks.conv_module'])
+
+        >>> recorder_cfg_ = copy.deepcopy(recorder_cfg)
+        >>> recorder_cfg_['type'] = recorder_cfg['type'] + 'Recorder'
+        >>> ctx = build_recorder(recorder_cfg_)
+        >>> ctx.initialize()
+
+        >>> with ctx:
+        >>>     conv = ConvModule(1,1,1)
+
+        >>> ctx.data_buffer
+        >>> {'mmcv.cnn.bricks.conv_module.build_conv_layer':
+        >>>     [Conv2d(1, 1, kernel_size=(1, 1), stride=(1, 1))]
+    """
+
+    def __init__(self, sources: List, import_modules: List):
+        super().__init__()
+        self.sources: List(str) = sources
+        self.import_modules: List(str) = import_modules
+
+    def prepare_from_model(self, model: Optional[nn.Module] = None) -> None:
+        """Wrapper the origin source functions.
+
+        The ``model`` is useless in this recorder, just to be consistent with
+        other recorders.
+        """
+        for func_name, module_name in zip(self.sources, self.import_modules):
+            if module_name is None:
+                origin_func = eval(f'{func_name}')
+            else:
+                # import the function corrosponding module
+                imported_module = import_modules_from_strings(  # noqa: F841
+                    module_name)
+                origin_func = eval(f'imported_module.{func_name}')
+            buffer_key = f'{module_name}.{func_name}'
+            # init data_buffer, data_buffer must be Dict(str, list)
+            # assume a func execute N times, there will be N outputs need to
+            # save.
+            self.data_buffer[buffer_key] = list()
+            # add record wrapper to origin function.
+            wrapped_func = self.func_record_wrapper(  # noqa: F841
+                origin_func, buffer_key)
+
+            if module_name is None:
+                exec(f'{func_name} = wrapped_func')
+            else:
+                exec(f'imported_module.{func_name} = wrapped_func')
+
+    def func_record_wrapper(self, origin_func: FunctionType,
+                            buffer_key: str) -> FunctionType:
+        """Save the function's outputs.
+
+        Args:
+            origin_func (FunctionType): The method whose outputs need to be
+                recorded.
+            buffer_key (str): The key of the function's outputs saved in
+                ``data_buffer``.
+        """
+
+        @functools.wraps(origin_func)
+        def wrap_func(*args, **kwargs):
+            outputs = origin_func(*args, **kwargs)
+            if self.recording:
+                self.data_buffer[buffer_key].append(outputs)
+            return outputs
+
+        return wrap_func

--- a/mmrazor/core/recorders/method_outputs_recorder.py
+++ b/mmrazor/core/recorders/method_outputs_recorder.py
@@ -1,0 +1,107 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import functools
+from types import MethodType
+from typing import Optional, Any, Dict, List
+from torch import nn
+from mmcv.utils import import_modules_from_strings
+
+from ..builder import RECORDERS
+from .base_recorder import BaseRecorder
+
+
+@RECORDERS.register_module()
+class MethodOutputsRecorder(BaseRecorder):
+    """Recorder for intermediate results which are ``MethodType``'s outputs.
+    
+    Note:
+        Different from ``FunctionType``, ``MethodType`` is the type of methods 
+        of class instances.
+
+    Args:
+        sources (List(str)): The names of the methods whose output needs to be 
+            recorded.
+        import_modules (List(str)): The modules which source methods belong to. 
+    
+    Examples:
+        >>> import copy
+        >>> import torch
+        >>> from mmcv.cnn import ConvModule
+        >>> from mmrazor.core import build_recorder
+
+        >>> # example recorder config
+        >>> recorder_cfg = dict(
+        >>>     type='MethodOutputs',
+        >>>     sources=['ConvModule.forward'],
+        >>>     import_modules=['mmcv.cnn'])
+    
+        >>> recorder_cfg_ = copy.deepcopy(recorder_cfg)
+        >>> recorder_cfg_['type'] = recorder_cfg['type'] + 'Recorder'
+        >>> ctx = build_recorder(recorder_cfg_)
+        >>> ctx.initialize()
+
+        >>> conv = ConvModule(1,1,1)
+        >>> with ctx:
+        >>>     res = conv(torch.randn(1,1,1,1))
+
+        >>> ctx.data_buffer
+        >>> {'mmcv.cnn.ConvModule.forward': [tensor([[[[0.]]]])]}
+        >>> ctx.get_record_data('mmcv.cnn.ConvModule.forward')
+        >>> [tensor([[[[0.]]]])]
+        >>> ctx.get_record_data('mmcv.cnn.ConvModule.forward', data_index=0)
+        >>> tensor([[[[0.]]]])
+    """
+    def __init__(self, sources: List, import_modules: List):
+        super().__init__()
+        self.sources: List(str) = sources
+        self.import_modules: List(str) = import_modules
+
+    def prepare_from_model(self, model: nn.Module) -> None:
+        """Wrapper the origin source methods.
+        The ``model`` is useless in this recorder, just to be consistent with 
+        other recorders.
+        """
+
+        for method_name, module_name in zip(self.sources, self.import_modules):
+            
+            if module_name is None:
+                origin_method = eval(f'{method_name}')
+            else:
+                # import the method corrosponding module
+                imported_module = import_modules_from_strings(  # noqa: F841
+                    module_name)
+                origin_method = eval(f'imported_module.{method_name}')
+
+            buffer_key = f'{module_name}.{method_name}'
+            # init data_buffer, data_buffer must be Dict(str, list)
+            # assume a method execute N times, there will be N outputs need to 
+            # save.
+            self.data_buffer[buffer_key] = list()
+            # add record wrapper to origin method.
+            wrapped_method = self.method_record_wrapper(  # noqa: F841
+                origin_method, buffer_key)
+            
+            if module_name is None:
+                exec(f'{method_name} = wrapped_method')
+            else:
+                exec(f'imported_module.{method_name} = wrapped_method')
+
+    def method_record_wrapper(self, 
+                              orgin_method: MethodType, 
+                              buffer_key: str) -> MethodType:
+        """Save the method's outputs.
+        
+        Args:
+            origin_method (MethodType): The method whose outputs need to be 
+                recorded.
+            buffer_key (str): The key of the method's outputs saved in 
+                ``data_buffer``.
+        """
+
+        @functools.wraps(orgin_method)
+        def wrap_method(*args, **kwargs):
+            outputs = orgin_method(*args, **kwargs)
+            if self.recording:
+                self.data_buffer[buffer_key].append(outputs)
+            return outputs
+
+        return wrap_method

--- a/mmrazor/core/recorders/method_outputs_recorder.py
+++ b/mmrazor/core/recorders/method_outputs_recorder.py
@@ -1,9 +1,10 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import functools
 from types import MethodType
-from typing import Optional, Any, Dict, List
-from torch import nn
+from typing import List
+
 from mmcv.utils import import_modules_from_strings
+from torch import nn
 
 from ..builder import RECORDERS
 from .base_recorder import BaseRecorder
@@ -12,16 +13,16 @@ from .base_recorder import BaseRecorder
 @RECORDERS.register_module()
 class MethodOutputsRecorder(BaseRecorder):
     """Recorder for intermediate results which are ``MethodType``'s outputs.
-    
+
     Note:
-        Different from ``FunctionType``, ``MethodType`` is the type of methods 
+        Different from ``FunctionType``, ``MethodType`` is the type of methods
         of class instances.
 
     Args:
-        sources (List(str)): The names of the methods whose output needs to be 
+        sources (List(str)): The names of the methods whose output needs to be
             recorded.
-        import_modules (List(str)): The modules which source methods belong to. 
-    
+        import_modules (List(str)): The modules which source methods belong to.
+
     Examples:
         >>> import copy
         >>> import torch
@@ -33,7 +34,7 @@ class MethodOutputsRecorder(BaseRecorder):
         >>>     type='MethodOutputs',
         >>>     sources=['ConvModule.forward'],
         >>>     import_modules=['mmcv.cnn'])
-    
+
         >>> recorder_cfg_ = copy.deepcopy(recorder_cfg)
         >>> recorder_cfg_['type'] = recorder_cfg['type'] + 'Recorder'
         >>> ctx = build_recorder(recorder_cfg_)
@@ -50,6 +51,7 @@ class MethodOutputsRecorder(BaseRecorder):
         >>> ctx.get_record_data('mmcv.cnn.ConvModule.forward', data_index=0)
         >>> tensor([[[[0.]]]])
     """
+
     def __init__(self, sources: List, import_modules: List):
         super().__init__()
         self.sources: List(str) = sources
@@ -57,12 +59,13 @@ class MethodOutputsRecorder(BaseRecorder):
 
     def prepare_from_model(self, model: nn.Module) -> None:
         """Wrapper the origin source methods.
-        The ``model`` is useless in this recorder, just to be consistent with 
+
+        The ``model`` is useless in this recorder, just to be consistent with
         other recorders.
         """
 
         for method_name, module_name in zip(self.sources, self.import_modules):
-            
+
             if module_name is None:
                 origin_method = eval(f'{method_name}')
             else:
@@ -73,27 +76,26 @@ class MethodOutputsRecorder(BaseRecorder):
 
             buffer_key = f'{module_name}.{method_name}'
             # init data_buffer, data_buffer must be Dict(str, list)
-            # assume a method execute N times, there will be N outputs need to 
+            # assume a method execute N times, there will be N outputs need to
             # save.
             self.data_buffer[buffer_key] = list()
             # add record wrapper to origin method.
             wrapped_method = self.method_record_wrapper(  # noqa: F841
                 origin_method, buffer_key)
-            
+
             if module_name is None:
                 exec(f'{method_name} = wrapped_method')
             else:
                 exec(f'imported_module.{method_name} = wrapped_method')
 
-    def method_record_wrapper(self, 
-                              orgin_method: MethodType, 
+    def method_record_wrapper(self, orgin_method: MethodType,
                               buffer_key: str) -> MethodType:
         """Save the method's outputs.
-        
+
         Args:
-            origin_method (MethodType): The method whose outputs need to be 
+            origin_method (MethodType): The method whose outputs need to be
                 recorded.
-            buffer_key (str): The key of the method's outputs saved in 
+            buffer_key (str): The key of the method's outputs saved in
                 ``data_buffer``.
         """
 

--- a/mmrazor/core/recorders/module_inputs_recorder.py
+++ b/mmrazor/core/recorders/module_inputs_recorder.py
@@ -1,0 +1,94 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from typing import Optional, Any, Dict, List
+from torch import nn
+
+from ..builder import RECORDERS
+from .base_recorder import BaseRecorder
+
+
+@RECORDERS.register_module()
+class ModuleInputsRecorder(BaseRecorder):
+    """Recorder for intermediate results which are Pytorch moudle's inputs.
+    
+    Args:
+        sources List(str): The names of the Pytorch modules whose input needs 
+        to be recorded.
+
+        Examples:
+            >>> import copy
+            >>> from torch.nn import Module, ModuleList, Conv2d
+            >>> from mmrazor.core import build_recorder
+            
+            >>> # example module
+            >>> class RepeatModule(Module):
+            >>>     def __init__(self) -> None:
+            >>>         super().__init__()
+            >>>     def forward(self, x):
+            >>>         outputs = list()
+            >>>         for i in range(2):
+            >>>             outputs.append(x * i)
+            >>>         return outputs
+
+            >>> # example model
+            >>> class Model(Module):
+            >>>     def __init__(self) -> None:
+            >>>        super().__init__()
+            >>>        self.repeat_module1 = RepeatModule()
+            >>>        self.repeat_module2 = RepeatModule()
+            >>>     def forward(self, x):
+            >>>        out = self.repeat_module1(x)
+            >>>        out = self.repeat_module2(x)
+            >>>        return out
+
+            >>> # example recorder config
+            >>> recorder_cfg = dict(
+            >>>     type='ModuleInputs',
+            >>>     sources=['repeat_module1', 'repeat_module2'])
+            >>> recorder_cfg_ = copy.deepcopy(recorder_cfg)
+            >>> recorder_cfg_.type = recorder_cfg.type + 'Recorder'
+
+            >>> ctx = build_recorder(recorder_cfg_)
+            >>> model = Model()
+            >>> ctx.initialize(model)
+
+            >>> with ctx:
+            >>>     res = model(torch.ones(2))
+
+            >>> ctx.data_buffer
+            >>> {'repeat_module1': [(tensor([1., 1.]),)], 
+                 'repeat_module2': [(tensor([1., 1.]),)]}
+            >>> ctx.get_record_data('repeat_module1')
+            >>> [(tensor([1., 1.]),)]
+            >>> ctx.get_record_data('repeat_module1', data_index=1)
+            >>> (tensor([1., 1.]),)
+    """
+    def __init__(self, sources: List):
+        super().__init__()
+        self.sources: List(str) = sources
+
+    def prepare_from_model(self, model: nn.Module) -> None:
+        """Register Pytorch forward hook to corresponding module."""
+
+        self.module2name: Dict(nn.Module, str) = dict()
+        for module_name, module in model.named_modules():
+            self.module2name[module] = module_name
+            
+        self.name2module: Dict(str, nn.Module) = dict(model.named_modules())
+
+        for module_name in self.sources:
+            self.data_buffer[module_name] = list()
+            module = self.name2module[module_name]
+            module.register_forward_hook(self.forward_input_hook) 
+
+    def forward_input_hook(self, module, inputs, outputs) -> None:
+        """Save the module's forward input.
+
+        Args:
+            module (:obj:`torch.nn.Module`): The module to register hook.
+            inputs (tuple): The input of the module.
+            outputs (tuple): The output of the module.
+        """
+        if self.recording:
+            module_name = self.module2name[module]
+            # self.data_buffer: Dict(str, list)
+            self.data_buffer[module_name].append(inputs)

--- a/mmrazor/core/recorders/param_recorder.py
+++ b/mmrazor/core/recorders/param_recorder.py
@@ -1,6 +1,8 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from typing import Optional, Any, Dict, List
+from typing import List
+
 from torch import nn
+
 from ..builder import RECORDERS
 from .base_recorder import BaseRecorder
 
@@ -8,10 +10,10 @@ from .base_recorder import BaseRecorder
 @RECORDERS.register_module()
 class ParameterRecorder(BaseRecorder):
     """Recorder for Pytorch model's parameters.
-    
+
     Args:
         sources List(str): The names of the parameters need to be recorded.
-    
+
     Examples:
         >>> import copy
         >>> import torch
@@ -22,7 +24,7 @@ class ParameterRecorder(BaseRecorder):
         >>> recorder_cfg = dict(
         >>>     type='Parameter',
         >>>     sources=['conv.weight'])
-    
+
         >>> recorder_cfg_ = copy.deepcopy(recorder_cfg)
         >>> recorder_cfg_['type'] = recorder_cfg['type'] + 'Recorder'
         >>> ctx = build_recorder(recorder_cfg_)
@@ -31,13 +33,14 @@ class ParameterRecorder(BaseRecorder):
         >>> ctx.initialize(conv)
 
         >>> ctx.data_buffer
-        >>> {'conv.weight': [Parameter containing: 
+        >>> {'conv.weight': [Parameter containing:
               tensor([[[[0.3244]]]], requires_grad=True)]}
         >>> ctx.get_record_data('conv.weight')
         >>> [Parameter containing: tensor([[[[0.3244]]]], requires_grad=True)]
         >>> ctx.get_record_data('conv.weight', data_index=0)
         >>> Parameter containing: tensor([[[[0.3244]]]], requires_grad=True)
     """
+
     def __init__(self, sources: List):
         super().__init__()
         self.sources: List(str) = sources
@@ -47,15 +50,15 @@ class ParameterRecorder(BaseRecorder):
         for param_name, param in model.named_parameters():
             if param_name in self.sources:
                 # init data_buffer, data_buffer must be Dict(str, list)
-                # param is not necessary saved in List,  just to be consistent 
+                # param is not necessary saved in List,  just to be consistent
                 # with other recorders.
                 self.data_buffer[param_name] = [param]
 
     def reset_data_buffer(self):
         """Clear data in data_buffer.
-        
+
         Note:
-            The data_buffer stores the address of the parameter in memory and 
+            The data_buffer stores the address of the parameter in memory and
             does not need to be reset
         """
         pass

--- a/mmrazor/core/recorders/param_recorder.py
+++ b/mmrazor/core/recorders/param_recorder.py
@@ -1,0 +1,61 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from typing import Optional, Any, Dict, List
+from torch import nn
+from ..builder import RECORDERS
+from .base_recorder import BaseRecorder
+
+
+@RECORDERS.register_module()
+class ParameterRecorder(BaseRecorder):
+    """Recorder for Pytorch model's parameters.
+    
+    Args:
+        sources List(str): The names of the parameters need to be recorded.
+    
+    Examples:
+        >>> import copy
+        >>> import torch
+        >>> from mmcv.cnn import ConvModule
+        >>> from mmrazor.core import build_recorder
+
+        >>> # example recorder config
+        >>> recorder_cfg = dict(
+        >>>     type='Parameter',
+        >>>     sources=['conv.weight'])
+    
+        >>> recorder_cfg_ = copy.deepcopy(recorder_cfg)
+        >>> recorder_cfg_['type'] = recorder_cfg['type'] + 'Recorder'
+        >>> ctx = build_recorder(recorder_cfg_)
+
+        >>> conv = ConvModule(1,1,1)
+        >>> ctx.initialize(conv)
+
+        >>> ctx.data_buffer
+        >>> {'conv.weight': [Parameter containing: 
+              tensor([[[[0.3244]]]], requires_grad=True)]}
+        >>> ctx.get_record_data('conv.weight')
+        >>> [Parameter containing: tensor([[[[0.3244]]]], requires_grad=True)]
+        >>> ctx.get_record_data('conv.weight', data_index=0)
+        >>> Parameter containing: tensor([[[[0.3244]]]], requires_grad=True)
+    """
+    def __init__(self, sources: List):
+        super().__init__()
+        self.sources: List(str) = sources
+
+    def prepare_from_model(self, model: nn.Module) -> None:
+        """Record the Pytorch model's parameters."""
+        for param_name, param in model.named_parameters():
+            if param_name in self.sources:
+                # init data_buffer, data_buffer must be Dict(str, list)
+                # param is not necessary saved in List,  just to be consistent 
+                # with other recorders.
+                self.data_buffer[param_name] = [param]
+
+    def reset_data_buffer(self):
+        """Clear data in data_buffer.
+        
+        Note:
+            The data_buffer stores the address of the parameter in memory and 
+            does not need to be reset
+        """
+        pass

--- a/mmrazor/core/recorders/recorder_manager.py
+++ b/mmrazor/core/recorders/recorder_manager.py
@@ -1,0 +1,129 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import copy
+from typing import Any, Dict, Optional
+
+from ..builder import build_recorder
+from .base_recorder import BaseRecorder
+
+
+class RecorderManager():
+    """Various types recorders' manager. The ``RecorderManager`` also is a
+    context manager, managing various types of Recorder. When entering the
+    ``RecorderManager``, all recorders managed by it will be started.
+
+    Note:
+        The recorders will be initialized in the ``RecorderManager`` by
+        default. If you want to just use a recorder without the
+        ``RecorderManager``, you need to initialize it first.
+
+    Note:
+        Recorders are managed by type. There can only be at most one recorder
+        of each type. If you have multiple same type's source data, just need
+        to add ``sources`` in your config.
+
+    Args:
+        recorders (list(dict)): All recorders' config.
+
+    Examples:
+            >>> from torch.nn import Module, ModuleList, Conv2d
+            >>> from mmrazor.core import RecorderManager
+
+            >>> # example module
+            >>> class RepeatModule(Module):
+            >>>     def __init__(self) -> None:
+            >>>         super().__init__()
+            >>>     def forward(self, x):
+            >>>         outputs = list()
+            >>>         for i in range(3):
+            >>>             outputs.append(x * i)
+            >>>         return outputs
+
+            >>> # example model
+            >>> class Model(Module):
+            >>>     def __init__(self) -> None:
+            >>>        super().__init__()
+            >>>        self.repeat_module1 = RepeatModule()
+            >>>        self.repeat_module2 = RepeatModule()
+            >>>     def forward(self, x):
+            >>>        out = self.repeat_module1(x)
+            >>>        out = self.repeat_module2(x)
+            >>>        return out
+
+            >>> # example recorder configs
+            >>> recorder_cfgs = [
+            >>>     dict(
+            >>>         type='ModuleOutputs',
+            >>>         sources=['repeat_module1', 'repeat_module2'])]
+
+            >>> ctx = RecorderManager(recorder_cfgs)
+            >>> model = Model()
+            >>> ctx.initialize(model)
+
+            >>> ctx.recorders
+            >>> {'ModuleOutputs': ModuleOutputsRecorder()}
+
+            >>> with ctx:
+            >>>     res = model(torch.ones(2))
+
+            >>> ctx.get_record_data('ModuleOutputs', 'repeat_module1')
+            >>> [(tensor([1., 1.]),)]
+            >>> ctx.get_record_data('ModuleOutputs',
+            >>>     'repeat_module1', data_index=1)
+            >>> (tensor([1., 1.]),)
+    """
+
+    def __init__(self, recorders) -> None:
+
+        self.recorders: Dict(str, BaseRecorder) = dict()
+        for cfg in recorders:
+            recorder_cfg = copy.deepcopy(cfg)
+            record_type = cfg.type
+            recorder_type = record_type + 'Recorder'
+            assert record_type not in self.recorders, \
+                f'{recorder_type} already exists. The recorders of the same \
+                    type should be merged into one. Please check your config.'
+
+            recorder_cfg.type = recorder_type
+            self.recorders[record_type] = build_recorder(recorder_cfg)
+
+    def get_record_data(self,
+                        record_type: str,
+                        source: str,
+                        data_index: Optional[int] = None) -> Any:
+        """Get data from corresponding recorder.
+
+        Args:
+            record_type (str): The type of recorder that the data belong to.
+            source (str): The key of the data saved in corresponding recorder's
+             ``data_buffer``.
+            data_index (int, optional):  The index of record source data. The
+                source data is a list saved in corresponding recorder's
+                ``data_buffer``.
+
+        Returns:
+            Any: The type of the return value is undefined, and different
+                source data may have different types.
+        """
+        recorder = self.recorders[record_type]
+        data = recorder.get_record_data(source, data_index)
+        return data
+
+    def initialize(self, model):
+        """Init all recorders.
+
+        Args:
+            model (nn.Module): The model which need to record intermediate
+                results.
+        """
+        for recorder in self.recorders.values():
+            recorder.initialize(model)
+
+    def __enter__(self):
+        """Enter the context manager."""
+        for recorder in self.recorders.values():
+            recorder.__enter__()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Exit the context manager."""
+        for recorder in self.recorders.values():
+            recorder.__exit__(exc_type, exc_value, traceback)


### PR DESCRIPTION
## Motivation

Currently, the distiller can only get the output of the PyTorch module, and MMRazor cannot reproduce some more complex distillation algorithms, such as #17 .

This pr designs a more robust mechanism for obtaining various data that the distillation algorithm may need, temporarily called `Recorder.`

Different types of data can be obtained by using different types of recorders.
`ModuleOutputsRecorder` can replace the original feature of obtaining module outputs in the distiller. 

Furthermore, there are `ModuleInputsRecorder` for obtaining module outputs, `FunctionOutputsRecorder` for obtaining python function's outputs, and      `ParameterRecorder` for obtaining the Pytorch module's parameter.





## Modification

1. Add recorder registry and build function
2. Add the base class for `Recorder.`
3. Implement some standard Recorders based on the base class.
4. Add a `RecorderManager` to manage various types of `Recorders`

## Use cases (Optional)

Every recorder's use case can be found in the corresponding class's doc-string

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
