### PR TITLE
[Docs] fix md link failure in docs

### DIFF
--- a/docs/en/conf.py
+++ b/docs/en/conf.py
@@ -44,7 +44,6 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
-    'recommonmark',
     'sphinx_markdown_tables',
     'sphinx_copybutton',
     'myst_parser'

--- a/docs/en/conf.py
+++ b/docs/en/conf.py
@@ -47,6 +47,7 @@ extensions = [
     'recommonmark',
     'sphinx_markdown_tables',
     'sphinx_copybutton',
+    'myst_parser'
 ]
 
 autodoc_mock_imports = [

--- a/docs/en/model_zoo.md
+++ b/docs/en/model_zoo.md
@@ -4,24 +4,24 @@
 
 ### CWD
 
-Please refer to [CWD](https://github.com/open-mmlab/mmrazor/blob/master/configs/distill/cwd/README.md) for details.
+Please refer to [CWD](https://github.com/open-mmlab/mmrazor/blob/master/configs/distill/cwd) for details.
 
 ### WSLD
 
-Please refer to [WSLD](https://github.com/open-mmlab/mmrazor/blob/master/configs/distill/wsld/README.md) for details.
+Please refer to [WSLD](https://github.com/open-mmlab/mmrazor/blob/master/configs/distill/wsld) for details.
 
 ### DARTS
 
-Please refer to [DARTS](https://github.com/open-mmlab/mmrazor/blob/master/configs/nas/darts/README.md) for details.
+Please refer to [DARTS](https://github.com/open-mmlab/mmrazor/blob/master/configs/nas/darts) for details.
 
 ### DETNAS
 
-Please refer to [DETNAS](https://github.com/open-mmlab/mmrazor/blob/master/configs/nas/detnas/README.md) for details.
+Please refer to [DETNAS](https://github.com/open-mmlab/mmrazor/blob/master/configs/nas/detnas) for details.
 
 ### SPOS
 
-Please refer to [SPOS](https://github.com/open-mmlab/mmrazor/blob/master/configs/nas/spos/README.md) for details.
+Please refer to [SPOS](https://github.com/open-mmlab/mmrazor/blob/master/configs/nas/spos) for details.
 
 ### AUTOSLIM
 
-Please refer to [AUTOSLIM](https://github.com/open-mmlab/mmrazor/blob/master/configs/pruning/autoslim/README.md) for details.
+Please refer to [AUTOSLIM](https://github.com/open-mmlab/mmrazor/blob/master/configs/pruning/autoslim) for details.

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -2,7 +2,6 @@ docutils==0.16.0
 m2r
 myst-parser
 git+https://github.com/open-mmlab/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
-recommonmark
 sphinx==4.0.2
 sphinx-copybutton
 sphinx_markdown_tables


### PR DESCRIPTION
## Motivation

The links in [mmrazor docs](https://mmrazor.readthedocs.io/en/latest/model_zoo.html) failed to direct to the right link.

## Modification

- delete readme.md from the link in model_zoo.md 
- add myst_parser to extension in conf.py  
- delete recommandmark in conf.py 
- delete deprecated recommandmark from requirments/docs.txt
