### PR TITLE
[Bug] Fix darts loop unittest

### DIFF
--- a/mmrazor/engine/runner/darts_loop.py
+++ b/mmrazor/engine/runner/darts_loop.py
@@ -47,15 +47,14 @@ class DartsEpochBasedTrainLoop(EpochBasedTrainLoop):
                 mutator_dataloader, seed=runner.seed)
         else:
             self.mutator_dataloader = mutator_dataloader
-        multi_loaders = [self.dataloader, self.mutator_dataloader]
-        self.multi_loaders = EpochMultiLoader(multi_loaders)
+        self.multi_loaders = [self.dataloader, self.mutator_dataloader]
 
     def run_epoch(self) -> None:
         """Iterate one epoch."""
         self.runner.call_hook('before_train_epoch')
         self.runner.model.train()
 
-        for idx, data_batch in enumerate(self.multi_loaders):
+        for idx, data_batch in enumerate(EpochMultiLoader(self.multi_loaders)):
             self.run_iter(idx, data_batch)
 
         self.runner.call_hook('after_train_epoch')

--- a/tests/test_runners/test_darts_loop.py
+++ b/tests/test_runners/test_darts_loop.py
@@ -150,7 +150,6 @@ class TestDartsLoop(TestCase):
         self.assertEqual(loop.max_epochs, 3)
         self.assertEqual(loop.max_iters, 12)
         self.assertIsInstance(loop.mutator_dataloader, DataLoader)
-        self.assertEqual(loop.multi_loaders.num_loaders, 2)
 
         # 2. DartsIterBasedTrainLoop
         cfg = copy.deepcopy(self.iter_based_cfg)
@@ -162,7 +161,6 @@ class TestDartsLoop(TestCase):
         self.assertIsInstance(loop.runner, Runner)
         self.assertEqual(loop.max_iters, 12)
         self.assertIsInstance(loop.mutator_dataloader, DataLoader)
-        self.assertEqual(loop.multi_loaders.num_loaders, 2)
 
     def test_run(self):
         # 1. test DartsEpochBasedTrainLoop


### PR DESCRIPTION
## Modification
fixed darts loop unittest, passed pre-commit and pytest in local 


## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
