### PR TITLE
[Refactor] Move `build_arch_param` from `DiffMutableModule` to `DiffModuleMutator`

### DIFF
--- a/mmrazor/models/mutables/mutable_module/diff_mutable_module.py
+++ b/mmrazor/models/mutables/mutable_module/diff_mutable_module.py
@@ -228,9 +228,11 @@ class DiffMutableOP(DiffMutableModule[str, str]):
         self.is_fixed = True
 
     def sample_choice(self, arch_param):
+        """Sample choice based on arch_parameters."""
         return self.choices[torch.argmax(arch_param).item()]
 
     def dump_chosen(self):
+        """Dump current choice."""
         assert self.current_choice is not None
         return self.current_choice
 
@@ -402,10 +404,12 @@ class DiffChoiceRoute(DiffMutableModule[str, List[str]]):
         return list(self._candidates.keys())
 
     def dump_chosen(self):
+        """dump current choice."""
         assert self.current_choice is not None
         return self.current_choice
 
     def sample_choice(self, arch_param):
+        """sample choice based on `arch_param`."""
         sort_idx = torch.argsort(-arch_param).cpu().numpy().tolist()
         choice_idx = sort_idx[:self.num_chosen]
         choice = [self.choices[i] for i in choice_idx]

--- a/mmrazor/models/mutables/mutable_module/diff_mutable_module.py
+++ b/mmrazor/models/mutables/mutable_module/diff_mutable_module.py
@@ -58,10 +58,6 @@ class DiffMutableModule(MutableModule[CHOICE_TYPE, CHOSEN_TYPE]):
         else:
             return self.forward_arch_param(x, arch_param=arch_param)
 
-    def build_arch_param(self) -> nn.Parameter:
-        """Build learnable architecture parameters."""
-        return nn.Parameter(torch.randn(self.num_choices) * 1e-3)
-
     def compute_arch_probs(self, arch_param: nn.Parameter) -> Tensor:
         """compute chosen probs according to architecture params."""
         return F.softmax(arch_param, -1)

--- a/mmrazor/models/mutators/module_mutator/diff_module_mutator.py
+++ b/mmrazor/models/mutators/module_mutator/diff_module_mutator.py
@@ -1,6 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from typing import Any, Dict, List, Optional
 
+import torch
 import torch.nn as nn
 
 from mmrazor.registry import MODELS
@@ -28,6 +29,10 @@ class DiffModuleMutator(ModuleMutator):
                  init_cfg: Optional[Dict] = None) -> None:
         super().__init__(custom_group=custom_group, init_cfg=init_cfg)
 
+    def build_arch_param(self, num_choices) -> nn.Parameter:
+        """Build learnable architecture parameters."""
+        return nn.Parameter(torch.randn(num_choices) * 1e-3)
+
     def prepare_from_supernet(self, supernet: nn.Module) -> None:
         """Inherit from ``BaseMutator``'s, generate `arch_params` in DARTS.
 
@@ -53,7 +58,7 @@ class DiffModuleMutator(ModuleMutator):
         arch_params = nn.ParameterDict()
 
         for group_id, modules in self.search_groups.items():
-            group_arch_param = modules[0].build_arch_param()
+            group_arch_param = self.build_arch_param(modules[0].num_choices)
             arch_params[str(group_id)] = group_arch_param
 
         return arch_params

--- a/tests/test_models/test_algorithms/test_autoslim.py
+++ b/tests/test_models/test_algorithms/test_autoslim.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock
 import pytest
 import torch
 import torch.distributed as dist
-from mmcls.data import ClsDataSample
+from mmcls.structures import ClsDataSample
 from mmengine.optim import build_optim_wrapper
 
 from mmrazor import digit_version

--- a/tests/test_models/test_algorithms/test_slimmable_network.py
+++ b/tests/test_models/test_algorithms/test_slimmable_network.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock
 import pytest
 import torch
 import torch.distributed as dist
-from mmcls.data import ClsDataSample
+from mmcls.structures import ClsDataSample
 from mmcv import fileio
 from mmengine.optim import build_optim_wrapper
 

--- a/tests/test_models/test_mutables/test_diffchoiceroute.py
+++ b/tests/test_models/test_mutables/test_diffchoiceroute.py
@@ -56,6 +56,15 @@ class TestDiffChoiceRoute(TestCase):
 
         new_diff_choice_route.fix_chosen(chosen=['first_edge'])
 
+        # test sample choice
+        arch_param = mutator.build_arch_param(
+            new_diff_choice_route.num_choices)
+        new_diff_choice_route.sample_choice(arch_param)
+
+        # test dump_chosen
+        with pytest.raises(AssertionError):
+            new_diff_choice_route.dump_chosen()
+
     def test_forward_fixed(self):
         edges_dict = nn.ModuleDict({
             'first_edge': nn.Conv2d(32, 32, 3, 1, 1),

--- a/tests/test_models/test_mutables/test_diffchoiceroute.py
+++ b/tests/test_models/test_mutables/test_diffchoiceroute.py
@@ -6,7 +6,6 @@ import torch
 import torch.nn as nn
 
 from mmrazor.models import *  # noqa:F403,F401
-from mmrazor.models.mutators import DiffModuleMutator
 from mmrazor.registry import MODELS
 
 MODELS.register_module(name='torchConv2d', module=nn.Conv2d, force=True)
@@ -30,9 +29,6 @@ class TestDiffChoiceRoute(TestCase):
 
         # test with_arch_param = True
         diffchoiceroute = MODELS.build(diff_choice_route_cfg)
-        mutator = DiffModuleMutator()
-        mutator.prepare_from_supernet(diffchoiceroute)
-
         arch_param = nn.Parameter(torch.randn(len(edges_dict)))
 
         x = [torch.randn(4, 32, 64, 64) for _ in range(5)]
@@ -44,9 +40,6 @@ class TestDiffChoiceRoute(TestCase):
         new_diff_choice_route_cfg['with_arch_param'] = False
 
         new_diff_choice_route = MODELS.build(new_diff_choice_route_cfg)
-
-        mutator.prepare_from_supernet(new_diff_choice_route)
-
         arch_param = nn.Parameter(torch.randn(len(edges_dict)))
         output = new_diff_choice_route.forward_arch_param(
             x=x, arch_param=arch_param)

--- a/tests/test_models/test_mutables/test_diffchoiceroute.py
+++ b/tests/test_models/test_mutables/test_diffchoiceroute.py
@@ -6,6 +6,7 @@ import torch
 import torch.nn as nn
 
 from mmrazor.models import *  # noqa:F403,F401
+from mmrazor.models.mutators import DiffModuleMutator
 from mmrazor.registry import MODELS
 
 MODELS.register_module(name='torchConv2d', module=nn.Conv2d, force=True)
@@ -29,8 +30,10 @@ class TestDiffChoiceRoute(TestCase):
 
         # test with_arch_param = True
         diffchoiceroute = MODELS.build(diff_choice_route_cfg)
+        mutator = DiffModuleMutator()
+        mutator.prepare_from_supernet(diffchoiceroute)
 
-        arch_param = diffchoiceroute.build_arch_param()
+        arch_param = mutator.build_arch_param(num_choices=len(edges_dict))
         assert len(arch_param) == 5
 
         x = [torch.randn(4, 32, 64, 64) for _ in range(5)]
@@ -44,7 +47,9 @@ class TestDiffChoiceRoute(TestCase):
 
         new_diff_choice_route = MODELS.build(new_diff_choice_route_cfg)
 
-        arch_param = new_diff_choice_route.build_arch_param()
+        mutator.prepare_from_supernet(new_diff_choice_route)
+
+        arch_param = mutator.build_arch_param(num_choices=len(edges_dict))
         output = new_diff_choice_route.forward_arch_param(
             x=x, arch_param=arch_param)
         assert output is not None

--- a/tests/test_models/test_mutables/test_diffchoiceroute.py
+++ b/tests/test_models/test_mutables/test_diffchoiceroute.py
@@ -33,11 +33,9 @@ class TestDiffChoiceRoute(TestCase):
         mutator = DiffModuleMutator()
         mutator.prepare_from_supernet(diffchoiceroute)
 
-        arch_param = mutator.build_arch_param(num_choices=len(edges_dict))
-        assert len(arch_param) == 5
+        arch_param = nn.Parameter(torch.randn(len(edges_dict)))
 
         x = [torch.randn(4, 32, 64, 64) for _ in range(5)]
-
         output = diffchoiceroute.forward_arch_param(x=x, arch_param=arch_param)
         assert output is not None
 
@@ -49,7 +47,7 @@ class TestDiffChoiceRoute(TestCase):
 
         mutator.prepare_from_supernet(new_diff_choice_route)
 
-        arch_param = mutator.build_arch_param(num_choices=len(edges_dict))
+        arch_param = nn.Parameter(torch.randn(len(edges_dict)))
         output = new_diff_choice_route.forward_arch_param(
             x=x, arch_param=arch_param)
         assert output is not None
@@ -57,8 +55,7 @@ class TestDiffChoiceRoute(TestCase):
         new_diff_choice_route.fix_chosen(chosen=['first_edge'])
 
         # test sample choice
-        arch_param = mutator.build_arch_param(
-            new_diff_choice_route.num_choices)
+        arch_param = nn.Parameter(torch.randn(len(edges_dict)))
         new_diff_choice_route.sample_choice(arch_param)
 
         # test dump_chosen

--- a/tests/test_models/test_mutables/test_diffop.py
+++ b/tests/test_models/test_mutables/test_diffop.py
@@ -6,7 +6,6 @@ import torch
 import torch.nn as nn
 
 from mmrazor.models import *  # noqa:F403,F401
-from mmrazor.models.mutators import DiffModuleMutator
 from mmrazor.registry import MODELS
 
 MODELS.register_module(name='torchConv2d', module=nn.Conv2d, force=True)
@@ -41,8 +40,6 @@ class TestDiffOP(TestCase):
         op = MODELS.build(op_cfg)
         input = torch.randn(4, 32, 64, 64)
 
-        diffmutator = DiffModuleMutator()
-        diffmutator.prepare_from_supernet(op)
         arch_param = nn.Parameter(torch.randn(len(op_cfg['candidates'])))
         output = op.forward_arch_param(input, arch_param=arch_param)
         assert output is not None
@@ -109,8 +106,6 @@ class TestDiffOP(TestCase):
         input = torch.randn(4, 32, 64, 64)
 
         # test set_forward_args
-        diffmutator = DiffModuleMutator()
-        diffmutator.prepare_from_supernet(op)
         arch_param = nn.Parameter(torch.randn(len(op_cfg['candidates'])))
         op.set_forward_args(arch_param=arch_param)
         output = op.forward(input)

--- a/tests/test_models/test_mutables/test_diffop.py
+++ b/tests/test_models/test_mutables/test_diffop.py
@@ -43,7 +43,7 @@ class TestDiffOP(TestCase):
 
         diffmutator = DiffModuleMutator()
         diffmutator.prepare_from_supernet(op)
-        arch_param = diffmutator.build_arch_param(op.num_choices)
+        arch_param = nn.Parameter(torch.randn(len(op_cfg['candidates'])))
         output = op.forward_arch_param(input, arch_param=arch_param)
         assert output is not None
 
@@ -111,7 +111,7 @@ class TestDiffOP(TestCase):
         # test set_forward_args
         diffmutator = DiffModuleMutator()
         diffmutator.prepare_from_supernet(op)
-        arch_param = diffmutator.build_arch_param(op.num_choices)
+        arch_param = nn.Parameter(torch.randn(len(op_cfg['candidates'])))
         op.set_forward_args(arch_param=arch_param)
         output = op.forward(input)
         assert output is not None

--- a/tests/test_models/test_mutables/test_diffop.py
+++ b/tests/test_models/test_mutables/test_diffop.py
@@ -6,6 +6,7 @@ import torch
 import torch.nn as nn
 
 from mmrazor.models import *  # noqa:F403,F401
+from mmrazor.models.mutators import DiffModuleMutator
 from mmrazor.registry import MODELS
 
 MODELS.register_module(name='torchConv2d', module=nn.Conv2d, force=True)
@@ -40,7 +41,9 @@ class TestDiffOP(TestCase):
         op = MODELS.build(op_cfg)
         input = torch.randn(4, 32, 64, 64)
 
-        arch_param = op.build_arch_param()
+        diffmutator = DiffModuleMutator()
+        diffmutator.prepare_from_supernet(op)
+        arch_param = diffmutator.build_arch_param(op.num_choices)
         output = op.forward_arch_param(input, arch_param=arch_param)
         assert output is not None
 
@@ -48,7 +51,6 @@ class TestDiffOP(TestCase):
         assert output is not None
 
         # test when some element of arch_param is 0
-        arch_param = op.build_arch_param()
         arch_param = nn.Parameter(torch.ones(op.num_choices))
         output = op.forward_arch_param(input, arch_param=arch_param)
         assert output is not None
@@ -107,7 +109,9 @@ class TestDiffOP(TestCase):
         input = torch.randn(4, 32, 64, 64)
 
         # test set_forward_args
-        arch_param = op.build_arch_param()
+        diffmutator = DiffModuleMutator()
+        diffmutator.prepare_from_supernet(op)
+        arch_param = diffmutator.build_arch_param(op.num_choices)
         op.set_forward_args(arch_param=arch_param)
         output = op.forward(input)
         assert output is not None

--- a/tests/test_models/test_mutables/test_diffop.py
+++ b/tests/test_models/test_mutables/test_diffop.py
@@ -116,6 +116,10 @@ class TestDiffOP(TestCase):
         output = op.forward(input)
         assert output is not None
 
+        # test dump_chosen
+        with pytest.raises(AssertionError):
+            op.dump_chosen()
+
         # test forward when is_fixed is True
         op.fix_chosen('torch_conv2d_7x7')
         output = op.forward(input)

--- a/tests/test_models/test_mutables/test_gumbelchoiceroute.py
+++ b/tests/test_models/test_mutables/test_gumbelchoiceroute.py
@@ -36,7 +36,7 @@ class TestGumbelChoiceRoute(TestCase):
         mutator = DiffModuleMutator()
         mutator.prepare_from_supernet(GumbelChoiceRoute)
 
-        arch_param = mutator.build_arch_param(GumbelChoiceRoute.num_choices)
+        arch_param = nn.Parameter(torch.randn(len(edges_dict)))
         assert len(arch_param) == 5
         GumbelChoiceRoute.set_temperature(1.0)
 
@@ -53,8 +53,7 @@ class TestGumbelChoiceRoute(TestCase):
         new_gumbel_choice_route = MODELS.build(new_gumbel_choice_route_cfg)
         mutator.prepare_from_supernet(new_gumbel_choice_route)
 
-        arch_param = mutator.build_arch_param(
-            new_gumbel_choice_route.num_choices)
+        arch_param = nn.Parameter(torch.randn(len(edges_dict)))
         output = new_gumbel_choice_route.forward_arch_param(
             x=x, arch_param=arch_param)
         assert output is not None

--- a/tests/test_models/test_mutables/test_gumbelchoiceroute.py
+++ b/tests/test_models/test_mutables/test_gumbelchoiceroute.py
@@ -6,6 +6,7 @@ import torch
 import torch.nn as nn
 
 from mmrazor.models import *  # noqa:F403,F401
+from mmrazor.models.mutators import DiffModuleMutator
 from mmrazor.registry import MODELS
 
 MODELS.register_module(name='torchConv2d', module=nn.Conv2d, force=True)
@@ -32,8 +33,10 @@ class TestGumbelChoiceRoute(TestCase):
 
         # test with_arch_param = True
         GumbelChoiceRoute = MODELS.build(gumbel_choice_route_cfg)
+        mutator = DiffModuleMutator()
+        mutator.prepare_from_supernet(GumbelChoiceRoute)
 
-        arch_param = GumbelChoiceRoute.build_arch_param()
+        arch_param = mutator.build_arch_param(GumbelChoiceRoute.num_choices)
         assert len(arch_param) == 5
         GumbelChoiceRoute.set_temperature(1.0)
 
@@ -48,8 +51,10 @@ class TestGumbelChoiceRoute(TestCase):
         new_gumbel_choice_route_cfg['with_arch_param'] = False
 
         new_gumbel_choice_route = MODELS.build(new_gumbel_choice_route_cfg)
+        mutator.prepare_from_supernet(new_gumbel_choice_route)
 
-        arch_param = new_gumbel_choice_route.build_arch_param()
+        arch_param = mutator.build_arch_param(
+            new_gumbel_choice_route.num_choices)
         output = new_gumbel_choice_route.forward_arch_param(
             x=x, arch_param=arch_param)
         assert output is not None

--- a/tests/test_models/test_mutables/test_gumbelchoiceroute.py
+++ b/tests/test_models/test_mutables/test_gumbelchoiceroute.py
@@ -6,7 +6,6 @@ import torch
 import torch.nn as nn
 
 from mmrazor.models import *  # noqa:F403,F401
-from mmrazor.models.mutators import DiffModuleMutator
 from mmrazor.registry import MODELS
 
 MODELS.register_module(name='torchConv2d', module=nn.Conv2d, force=True)
@@ -33,8 +32,6 @@ class TestGumbelChoiceRoute(TestCase):
 
         # test with_arch_param = True
         GumbelChoiceRoute = MODELS.build(gumbel_choice_route_cfg)
-        mutator = DiffModuleMutator()
-        mutator.prepare_from_supernet(GumbelChoiceRoute)
 
         arch_param = nn.Parameter(torch.randn(len(edges_dict)))
         assert len(arch_param) == 5
@@ -51,7 +48,6 @@ class TestGumbelChoiceRoute(TestCase):
         new_gumbel_choice_route_cfg['with_arch_param'] = False
 
         new_gumbel_choice_route = MODELS.build(new_gumbel_choice_route_cfg)
-        mutator.prepare_from_supernet(new_gumbel_choice_route)
 
         arch_param = nn.Parameter(torch.randn(len(edges_dict)))
         output = new_gumbel_choice_route.forward_arch_param(

--- a/tests/test_models/test_mutators/test_classical_models/test_mbv2_channel_mutator.py
+++ b/tests/test_models/test_mutators/test_classical_models/test_mbv2_channel_mutator.py
@@ -4,8 +4,8 @@ import unittest
 from os.path import dirname
 
 import torch
-from mmcls.data import ClsDataSample
 from mmcls.models import *  # noqa: F401,F403
+from mmcls.structures import ClsDataSample
 
 from mmrazor import digit_version
 from mmrazor.models.mutables import SlimmableMutableChannel

--- a/tests/test_runners/test_darts_loop.py
+++ b/tests/test_runners/test_darts_loop.py
@@ -150,7 +150,6 @@ class TestDartsLoop(TestCase):
         self.assertEqual(loop.max_epochs, 3)
         self.assertEqual(loop.max_iters, 12)
         self.assertIsInstance(loop.mutator_dataloader, DataLoader)
-        self.assertEqual(loop.multi_loaders.num_loaders, 2)
 
         # 2. DartsIterBasedTrainLoop
         cfg = copy.deepcopy(self.iter_based_cfg)
@@ -162,7 +161,6 @@ class TestDartsLoop(TestCase):
         self.assertIsInstance(loop.runner, Runner)
         self.assertEqual(loop.max_iters, 12)
         self.assertIsInstance(loop.mutator_dataloader, DataLoader)
-        self.assertEqual(loop.multi_loaders.num_loaders, 2)
 
     def test_run(self):
         # 1. test DartsEpochBasedTrainLoop


### PR DESCRIPTION
## Motivation

- [x] Move `build_arch_param` function from `DiffMutableModule` (including `DiffMutableOP`, `DiffChoiceRoute` and `GumbelChoiceRoute`) to `DiffModuleMutator`. 
- [x] Rename cls.data to cls.structures. For more information see: https://github.com/open-mmlab/mmclassification/pull/941 

## Modification

- [x] Move build_arch_param from `DiffMutableModule` to `DiffModuleMutator`.
- [x] Modify corresponding unittest. 
- [x] Pass the docstring coverage.

![image](https://user-images.githubusercontent.com/29230784/183032306-b1fa9318-ee2e-4042-b7be-1c1fbb92ef1d.png)

- [x] Add UT for `diff_mutable_module.py` and `diff_module_mutator.py`

Before add UT:

![image](https://user-images.githubusercontent.com/29230784/183036624-ebeee741-616a-4323-9fc3-2cc4d9ba577d.png)

After add UT: 

![image](https://user-images.githubusercontent.com/29230784/183045299-a9394a97-e93d-4e29-b70d-784073164fcb.png)

