### PR TITLE
[Fix] Fix `Protocol` import error when python<3.8

### DIFF
--- a/mmrazor/models/mutables/derived_mutable.py
+++ b/mmrazor/models/mutables/derived_mutable.py
@@ -1,8 +1,15 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import sys
+
+if sys.version_info < (3, 8):
+    from typing_extensions import Protocol
+else:
+    from typing import Protocol
+
 import inspect
 import logging
 from collections.abc import Iterable
-from typing import Any, Callable, Dict, Optional, Protocol, Set, Union
+from typing import Any, Callable, Dict, Optional, Set, Union
 
 import torch
 from mmengine.logging import print_log

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,2 +1,3 @@
 mmcls
 ordered_set
+typing_extensions;python_version<"3.8"


### PR DESCRIPTION
## Motivation

Fix `Protocol` import error when python<3.8.

## Modification

1. Import `Protocol` from typing_extensions when python<3.8
2. Add `typing_extensions` in requirements/runtime.txt when python<3.8