### PR TITLE
[Refactor] Refactor Mutables and Mutators

### DIFF
--- a/configs/nas/mmcls/darts/DARTS_SUBNET_CIFAR_PAPER_ALIAS.yaml
+++ b/configs/nas/mmcls/darts/DARTS_SUBNET_CIFAR_PAPER_ALIAS.yaml
@@ -1,56 +1,80 @@
 normal_n2:
-  - normal_n2_p0
-  - normal_n2_p1
+  chosen:
+    - normal_n2_p0
+    - normal_n2_p1
 normal_n2_p0:
-  - sep_conv_3x3
+  chosen:
+    - sep_conv_3x3
 normal_n2_p1:
-  - sep_conv_3x3
+  chosen:
+    - sep_conv_3x3
 normal_n3:
-  - normal_n3_p0
-  - normal_n3_p1
+  chosen:
+    - normal_n3_p0
+    - normal_n3_p1
 normal_n3_p0:
-  - skip_connect
+  chosen:
+    - skip_connect
 normal_n3_p1:
-  - sep_conv_5x5
+  chosen:
+    - sep_conv_5x5
 normal_n4:
-  - normal_n4_p0
-  - normal_n4_p1
+  chosen:
+    - normal_n4_p0
+    - normal_n4_p1
 normal_n4_p0:
-  - sep_conv_3x3
+  chosen:
+    - sep_conv_3x3
 normal_n4_p1:
-  - skip_connect
+  chosen:
+    - skip_connect
 normal_n5:
-  - normal_n5_p0
-  - normal_n5_p1
+  chosen:
+    - normal_n5_p0
+    - normal_n5_p1
 normal_n5_p0:
-  - skip_connect
+  chosen:
+    - skip_connect
 normal_n5_p1:
-  - skip_connect
+  chosen:
+    - skip_connect
 reduce_n2:
-  - reduce_n2_p0
-  - reduce_n2_p1
+  chosen:
+    - reduce_n2_p0
+    - reduce_n2_p1
 reduce_n2_p0:
-  - max_pool_3x3
+  chosen:
+    - max_pool_3x3
 reduce_n2_p1:
-  - sep_conv_3x3
+  chosen:
+    - sep_conv_3x3
 reduce_n3:
-  - reduce_n3_p0
-  - reduce_n3_p2
+  chosen:
+    - reduce_n3_p0
+    - reduce_n3_p2
 reduce_n3_p0:
-  - max_pool_3x3
+  chosen:
+    - max_pool_3x3
 reduce_n3_p2:
-  - dil_conv_5x5
+  chosen:
+    - dil_conv_5x5
 reduce_n4:
-  - reduce_n4_p0
-  - reduce_n4_p2
+  chosen:
+    - reduce_n4_p0
+    - reduce_n4_p2
 reduce_n4_p0:
-  - max_pool_3x3
+  chosen:
+    - max_pool_3x3
 reduce_n4_p2:
-  - skip_connect
+  chosen:
+    - skip_connect
 reduce_n5:
-  - reduce_n5_p0
-  - reduce_n5_p2
+  chosen:
+    - reduce_n5_p0
+    - reduce_n5_p2
 reduce_n5_p0:
-  - max_pool_3x3
+  chosen:
+    - max_pool_3x3
 reduce_n5_p2:
-  - skip_connect
+  chosen:
+    - skip_connect

--- a/configs/nas/mmcls/dsnas/dsnas_subnet_8xb128_in1k.py
+++ b/configs/nas/mmcls/dsnas/dsnas_subnet_8xb128_in1k.py
@@ -1,28 +1,7 @@
 _base_ = ['./dsnas_supernet_8xb128_in1k.py']
 
 # NOTE: Replace this with the mutable_cfg searched by yourself.
-fix_subnet = {
-    'backbone.layers.0.0': 'shuffle_3x3',
-    'backbone.layers.0.1': 'shuffle_7x7',
-    'backbone.layers.0.2': 'shuffle_3x3',
-    'backbone.layers.0.3': 'shuffle_5x5',
-    'backbone.layers.1.0': 'shuffle_3x3',
-    'backbone.layers.1.1': 'shuffle_3x3',
-    'backbone.layers.1.2': 'shuffle_3x3',
-    'backbone.layers.1.3': 'shuffle_7x7',
-    'backbone.layers.2.0': 'shuffle_xception',
-    'backbone.layers.2.1': 'shuffle_3x3',
-    'backbone.layers.2.2': 'shuffle_3x3',
-    'backbone.layers.2.3': 'shuffle_5x5',
-    'backbone.layers.2.4': 'shuffle_3x3',
-    'backbone.layers.2.5': 'shuffle_5x5',
-    'backbone.layers.2.6': 'shuffle_7x7',
-    'backbone.layers.2.7': 'shuffle_7x7',
-    'backbone.layers.3.0': 'shuffle_xception',
-    'backbone.layers.3.1': 'shuffle_3x3',
-    'backbone.layers.3.2': 'shuffle_7x7',
-    'backbone.layers.3.3': 'shuffle_3x3',
-}
+fix_subnet = 'configs/nas/mmcls/dsnas/DSNAS_SUBNET_IMAGENET_PAPER_ALIAS.yaml'
 
 model = dict(fix_subnet=fix_subnet)
 

--- a/configs/nas/mmcls/dsnas/dsnas_supernet_8xb128_in1k.py
+++ b/configs/nas/mmcls/dsnas/dsnas_supernet_8xb128_in1k.py
@@ -6,7 +6,7 @@ _base_ = [
 
 # model
 model = dict(
-    type='mmrazor.Dsnas',
+    type='mmrazor.DSNAS',
     architecture=dict(
         type='ImageClassifier',
         data_preprocessor=_base_.data_preprocessor,
@@ -29,7 +29,7 @@ model = dict(
 )
 
 model_wrapper_cfg = dict(
-    type='mmrazor.DsnasDDP',
+    type='mmrazor.DSNASDDP',
     broadcast_buffers=False,
     find_unused_parameters=True)
 

--- a/configs/nas/mmcls/spos/SPOS_SUBNET.yaml
+++ b/configs/nas/mmcls/spos/SPOS_SUBNET.yaml
@@ -1,23 +1,23 @@
 backbone.layers.0.0:
-  chosen: shuffle_3x3
+  chosen: shuffle_7x7
 backbone.layers.0.1:
-  chosen: shuffle_7x7
+  chosen: shuffle_3x3
 backbone.layers.0.2:
-  chosen: shuffle_3x3
-backbone.layers.0.3:
-  chosen: shuffle_5x5
-backbone.layers.1.0:
-  chosen: shuffle_3x3
-backbone.layers.1.1:
-  chosen: shuffle_3x3
-backbone.layers.1.2:
-  chosen: shuffle_3x3
-backbone.layers.1.3:
   chosen: shuffle_7x7
-backbone.layers.2.0:
-  chosen: shuffle_xception
-backbone.layers.2.1:
+backbone.layers.0.3:
   chosen: shuffle_3x3
+backbone.layers.1.0:
+  chosen: shuffle_xception
+backbone.layers.1.1:
+  chosen: shuffle_5x5
+backbone.layers.1.2:
+  chosen: shuffle_5x5
+backbone.layers.1.3:
+  chosen: shuffle_3x3
+backbone.layers.2.0:
+  chosen: shuffle_3x3
+backbone.layers.2.1:
+  chosen: shuffle_5x5
 backbone.layers.2.2:
   chosen: shuffle_3x3
 backbone.layers.2.3:
@@ -25,16 +25,16 @@ backbone.layers.2.3:
 backbone.layers.2.4:
   chosen: shuffle_3x3
 backbone.layers.2.5:
-  chosen: shuffle_5x5
+  chosen: shuffle_xception
 backbone.layers.2.6:
-  chosen: shuffle_7x7
+  chosen: shuffle_5x5
 backbone.layers.2.7:
   chosen: shuffle_7x7
 backbone.layers.3.0:
-  chosen: shuffle_xception
+  chosen: shuffle_7x7
 backbone.layers.3.1:
   chosen: shuffle_3x3
 backbone.layers.3.2:
-  chosen: shuffle_7x7
+  chosen: shuffle_5x5
 backbone.layers.3.3:
-  chosen: shuffle_3x3
+  chosen: shuffle_xception

--- a/configs/nas/mmcls/spos/spos_shufflenet_subnet_8xb128_in1k.py
+++ b/configs/nas/mmcls/spos/spos_shufflenet_subnet_8xb128_in1k.py
@@ -1,7 +1,7 @@
 _base_ = ['./spos_shufflenet_supernet_8xb128_in1k.py']
 
-# FIXME: you may replace this with the mutable_cfg searched by yourself
-fix_subnet = 'https://download.openmmlab.com/mmrazor/v1/spos/spos_shufflenetv2_subnet_8xb128_in1k_flops_0.33M_acc_73.87_20220715-aa94d5ef_subnet_cfg_v1.yaml'  # noqa: E501
+# FIXME: you may replace this with the searched by yourself
+fix_subnet = 'configs/nas/mmcls/spos/SPOS_SUBNET.yaml'
 
 model = dict(fix_subnet=fix_subnet)
 

--- a/configs/nas/mmdet/detnas/DETNAS_SUBNET.yaml
+++ b/configs/nas/mmdet/detnas/DETNAS_SUBNET.yaml
@@ -1,40 +1,40 @@
 backbone.layers.0.0:
-  chosen: shuffle_3x3
+  chosen: shuffle_5x5
 backbone.layers.0.1:
-  chosen: shuffle_7x7
+  chosen: shuffle_3x3
 backbone.layers.0.2:
   chosen: shuffle_3x3
 backbone.layers.0.3:
-  chosen: shuffle_5x5
-backbone.layers.1.0:
   chosen: shuffle_3x3
+backbone.layers.1.0:
+  chosen: shuffle_xception
 backbone.layers.1.1:
   chosen: shuffle_3x3
 backbone.layers.1.2:
-  chosen: shuffle_3x3
+  chosen: shuffle_xception
 backbone.layers.1.3:
   chosen: shuffle_7x7
 backbone.layers.2.0:
-  chosen: shuffle_xception
+  chosen: shuffle_7x7
 backbone.layers.2.1:
-  chosen: shuffle_3x3
+  chosen: shuffle_7x7
 backbone.layers.2.2:
-  chosen: shuffle_3x3
+  chosen: shuffle_xception
 backbone.layers.2.3:
-  chosen: shuffle_5x5
+  chosen: shuffle_xception
 backbone.layers.2.4:
   chosen: shuffle_3x3
 backbone.layers.2.5:
-  chosen: shuffle_5x5
+  chosen: shuffle_7x7
 backbone.layers.2.6:
-  chosen: shuffle_7x7
+  chosen:  shuffle_5x5
 backbone.layers.2.7:
-  chosen: shuffle_7x7
-backbone.layers.3.0:
   chosen: shuffle_xception
-backbone.layers.3.1:
-  chosen: shuffle_3x3
-backbone.layers.3.2:
+backbone.layers.3.0:
   chosen: shuffle_7x7
+backbone.layers.3.1:
+  chosen: shuffle_7x7
+backbone.layers.3.2:
+  chosen:  shuffle_7x7
 backbone.layers.3.3:
-  chosen: shuffle_3x3
+  chosen:  shuffle_5x5

--- a/configs/nas/mmdet/detnas/detnas_frcnn_shufflenet_subnet_coco_1x.py
+++ b/configs/nas/mmdet/detnas/detnas_frcnn_shufflenet_subnet_coco_1x.py
@@ -1,7 +1,7 @@
 _base_ = ['./detnas_frcnn_shufflenet_supernet_coco_1x.py']
 
 # FIXME: you may replace this with the searched by yourself
-fix_subnet = 'https://download.openmmlab.com/mmrazor/v1/detnas/detnas_subnet_frcnn_shufflenetv2_fpn_1x_coco_bbox_backbone_flops-0.34M_mAP-37.5_20220715-61d2e900_subnet_cfg_v1.yaml'  # noqa: E501
+fix_subnet = 'configs/nas/mmdet/detnas/DETNAS_SUBNET.yaml'
 
 model = dict(fix_subnet=fix_subnet)
 

--- a/mmrazor/models/algorithms/__init__.py
+++ b/mmrazor/models/algorithms/__init__.py
@@ -3,7 +3,7 @@ from .base import BaseAlgorithm
 from .distill import (DAFLDataFreeDistillation, DataFreeDistillation,
                       FpnTeacherDistill, OverhaulFeatureDistillation,
                       SelfDistill, SingleTeacherDistill)
-from .nas import SPOS, AutoSlim, AutoSlimDDP, Darts, DartsDDP, Dsnas, DsnasDDP
+from .nas import DSNAS, DSNASDDP, SPOS, AutoSlim, AutoSlimDDP, Darts, DartsDDP
 from .pruning import SlimmableNetwork, SlimmableNetworkDDP
 from .pruning.ite_prune_algorithm import ItePruneAlgorithm
 
@@ -23,6 +23,6 @@ __all__ = [
     'DAFLDataFreeDistillation',
     'OverhaulFeatureDistillation',
     'ItePruneAlgorithm',
-    'Dsnas',
-    'DsnasDDP',
+    'DSNAS',
+    'DSNASDDP',
 ]

--- a/mmrazor/models/algorithms/nas/__init__.py
+++ b/mmrazor/models/algorithms/nas/__init__.py
@@ -1,9 +1,9 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from .autoslim import AutoSlim, AutoSlimDDP
 from .darts import Darts, DartsDDP
-from .dsnas import Dsnas, DsnasDDP
+from .dsnas import DSNAS, DSNASDDP
 from .spos import SPOS
 
 __all__ = [
-    'SPOS', 'AutoSlim', 'AutoSlimDDP', 'Darts', 'DartsDDP', 'Dsnas', 'DsnasDDP'
+    'SPOS', 'AutoSlim', 'AutoSlimDDP', 'Darts', 'DartsDDP', 'DSNAS', 'DSNASDDP'
 ]

--- a/mmrazor/models/algorithms/nas/dsnas.py
+++ b/mmrazor/models/algorithms/nas/dsnas.py
@@ -23,7 +23,7 @@ from ..base import BaseAlgorithm
 
 
 @MODELS.register_module()
-class Dsnas(BaseAlgorithm):
+class DSNAS(BaseAlgorithm):
     """Implementation of `DSNAS <https://arxiv.org/abs/2002.09128>`_
 
     Args:
@@ -272,7 +272,7 @@ class Dsnas(BaseAlgorithm):
 
 
 @MODEL_WRAPPERS.register_module()
-class DsnasDDP(MMDistributedDataParallel):
+class DSNASDDP(MMDistributedDataParallel):
 
     def __init__(self,
                  *,

--- a/mmrazor/models/algorithms/pruning/ite_prune_algorithm.py
+++ b/mmrazor/models/algorithms/pruning/ite_prune_algorithm.py
@@ -86,7 +86,8 @@ class ItePruneAlgorithm(BaseAlgorithm):
 
     Args:
         architecture (Union[BaseModel, Dict]): The model to be pruned.
-        mutator_cfg (UnioChannelUnit. Defaults to dict( type='ChannelMutator',
+        mutator_cfg (Union[Dict, ChannelMutator], optional): The config
+            of a mutator. Defaults to dict( type='ChannelMutator',
             channel_unit_cfg=dict( type='SequentialMutableChannelUnit')).
         data_preprocessor (Optional[Union[Dict, nn.Module]], optional):
             Defaults to None.

--- a/mmrazor/models/mutables/base_mutable.py
+++ b/mmrazor/models/mutables/base_mutable.py
@@ -1,14 +1,13 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from abc import ABC, abstractmethod
-from typing import Dict, Generic, Optional, TypeVar
+from typing import Dict, Optional
 
 from mmengine.model import BaseModule
 
-CHOICE_TYPE = TypeVar('CHOICE_TYPE')
-CHOSEN_TYPE = TypeVar('CHOSEN_TYPE')
+from mmrazor.utils.typing import DumpChosen
 
 
-class BaseMutable(BaseModule, ABC, Generic[CHOICE_TYPE, CHOSEN_TYPE]):
+class BaseMutable(BaseModule, ABC):
     """Base Class for mutables. Mutable means a searchable module widely used
     in Neural Architecture Search(NAS).
 
@@ -24,11 +23,7 @@ class BaseMutable(BaseModule, ABC, Generic[CHOICE_TYPE, CHOSEN_TYPE]):
     Args:
         module_kwargs (dict[str, dict], optional): Module initialization named
             arguments. Defaults to None.
-        alias (str, optional): alias of the `MUTABLE`.
-        init_cfg (dict, optional): initialization configuration dict for
-            ``BaseModule``. OpenMMLab has implement 5 initializer including
-            `Constant`, `Xavier`, `Normal`, `Uniform`, `Kaiming`,
-            and `Pretrained`.
+        alias (str, optional): alias oraise NotImplementedError()
     """
 
     def __init__(self,
@@ -38,19 +33,18 @@ class BaseMutable(BaseModule, ABC, Generic[CHOICE_TYPE, CHOSEN_TYPE]):
 
         self.alias = alias
         self._is_fixed = False
-        self._current_choice: Optional[CHOICE_TYPE] = None
 
     @property
-    def current_choice(self) -> Optional[CHOICE_TYPE]:
+    def current_choice(self):
         """Current choice will affect :meth:`forward` and will be used in
         :func:`mmrazor.core.subnet.utils.export_fix_subnet` or mutator.
         """
-        return self._current_choice
+        raise NotImplementedError()
 
     @current_choice.setter
-    def current_choice(self, choice: Optional[CHOICE_TYPE]) -> None:
+    def current_choice(self, choice) -> None:
         """Current choice setter will be executed in mutator."""
-        self._current_choice = choice
+        raise NotImplementedError()
 
     @property
     def is_fixed(self) -> bool:
@@ -76,7 +70,7 @@ class BaseMutable(BaseModule, ABC, Generic[CHOICE_TYPE, CHOSEN_TYPE]):
         self._is_fixed = is_fixed
 
     @abstractmethod
-    def fix_chosen(self, chosen: CHOSEN_TYPE) -> None:
+    def fix_chosen(self, chosen) -> None:
         """Fix mutable with choice. This function would fix the choice of
         Mutable. The :attr:`is_fixed` will be set to True and only the selected
         operations can be retained. All subclasses must implement this method.
@@ -84,14 +78,14 @@ class BaseMutable(BaseModule, ABC, Generic[CHOICE_TYPE, CHOSEN_TYPE]):
         Note:
             This operation is irreversible.
         """
+        raise NotImplementedError()
 
     # TODO
     # type hint
     @abstractmethod
-    def dump_chosen(self) -> CHOSEN_TYPE:
-        ...
+    def dump_chosen(self) -> DumpChosen:
+        raise NotImplementedError()
 
-    @property
     @abstractmethod
-    def num_choices(self) -> int:
-        pass
+    def export_chosen(self):
+        raise NotImplementedError()

--- a/mmrazor/models/mutables/base_mutable.py
+++ b/mmrazor/models/mutables/base_mutable.py
@@ -1,16 +1,13 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from abc import ABC, abstractmethod
-from typing import Dict, Generic, Optional, TypeVar
+from typing import Dict, Optional
 
 from mmengine.model import BaseModule
 
 from mmrazor.utils.typing import DumpChosen
 
-Chosen = TypeVar('Chosen')
-Choice = TypeVar('Choice')
 
-
-class BaseMutable(BaseModule, ABC, Generic[Choice, Chosen]):
+class BaseMutable(BaseModule, ABC):
     """Base Class for mutables. Mutable means a searchable module widely used
     in Neural Architecture Search(NAS).
 
@@ -42,7 +39,7 @@ class BaseMutable(BaseModule, ABC, Generic[Choice, Chosen]):
 
     @property  # type: ignore
     @abstractmethod
-    def current_choice(self) -> Choice:
+    def current_choice(self):
         """Current choice will affect :meth:`forward` and will be used in
         :func:`mmrazor.core.subnet.utils.export_fix_subnet` or mutator.
         """
@@ -76,7 +73,7 @@ class BaseMutable(BaseModule, ABC, Generic[Choice, Chosen]):
         self._is_fixed = is_fixed
 
     @abstractmethod
-    def fix_chosen(self, chosen: Chosen) -> None:
+    def fix_chosen(self, chosen) -> None:
         """Fix mutable with choice. This function would fix the choice of
         Mutable. The :attr:`is_fixed` will be set to True and only the selected
         operations can be retained. All subclasses must implement this method.

--- a/mmrazor/models/mutables/base_mutable.py
+++ b/mmrazor/models/mutables/base_mutable.py
@@ -74,8 +74,8 @@ class BaseMutable(BaseModule, ABC):
 
     @abstractmethod
     def fix_chosen(self, chosen) -> None:
-        """Fix mutable with choice. This function would fix the choice of
-        Mutable. The :attr:`is_fixed` will be set to True and only the selected
+        """Fix mutable with chosen. This function would fix the chosen of
+        mutable. The :attr:`is_fixed` will be set to True and only the selected
         operations can be retained. All subclasses must implement this method.
 
         Note:
@@ -83,8 +83,6 @@ class BaseMutable(BaseModule, ABC):
         """
         raise NotImplementedError()
 
-    # TODO
-    # type hint
     @abstractmethod
     def dump_chosen(self) -> DumpChosen:
         """Save the current state of the mutable as a dictionary.

--- a/mmrazor/models/mutables/derived_mutable.py
+++ b/mmrazor/models/mutables/derived_mutable.py
@@ -15,8 +15,9 @@ import torch
 from mmengine.logging import print_log
 from torch import Tensor
 
+from mmrazor.utils.typing import DumpChosen
 from ..utils import make_divisible
-from .base_mutable import CHOICE_TYPE, BaseMutable
+from .base_mutable import BaseMutable
 
 
 class MutableProtocol(Protocol):  # pragma: no cover
@@ -172,8 +173,7 @@ class DerivedMethodMixin:
         return DerivedMutable(choice_fn=choice_fn, mask_fn=mask_fn)
 
 
-class DerivedMutable(BaseMutable[CHOICE_TYPE, CHOICE_TYPE],
-                     DerivedMethodMixin):
+class DerivedMutable(BaseMutable, DerivedMethodMixin):
     """Class for derived mutable.
 
     A derived mutable is a mutable derived from other mutables that has
@@ -242,7 +242,7 @@ class DerivedMutable(BaseMutable[CHOICE_TYPE, CHOICE_TYPE],
 
     # TODO
     # has no effect
-    def fix_chosen(self, chosen: CHOICE_TYPE) -> None:
+    def fix_chosen(self, chosen) -> None:
         """Fix mutable with subnet config.
 
         Warning:
@@ -253,7 +253,7 @@ class DerivedMutable(BaseMutable[CHOICE_TYPE, CHOICE_TYPE],
             'which will have no effect.',
             level=logging.WARNING)
 
-    def dump_chosen(self) -> CHOICE_TYPE:
+    def dump_chosen(self) -> DumpChosen:
         """Dump information of chosen.
 
         Returns:
@@ -263,6 +263,9 @@ class DerivedMutable(BaseMutable[CHOICE_TYPE, CHOICE_TYPE],
             'Trying to dump chosen for derived mutable, '
             'but its value depend on the source mutables.',
             level=logging.WARNING)
+        return DumpChosen(chosen=self.export_chosen(), meta=None)
+
+    def export_chosen(self):
         return self.current_choice
 
     @property
@@ -314,12 +317,12 @@ class DerivedMutable(BaseMutable[CHOICE_TYPE, CHOICE_TYPE],
         return 1
 
     @property
-    def current_choice(self) -> CHOICE_TYPE:
+    def current_choice(self):
         """Current choice of derived mutable."""
         return self.choice_fn()
 
     @current_choice.setter
-    def current_choice(self, choice: CHOICE_TYPE) -> None:
+    def current_choice(self, choice) -> None:
         """Setter of current choice.
 
         Raises:
@@ -367,7 +370,7 @@ class DerivedMutable(BaseMutable[CHOICE_TYPE, CHOICE_TYPE],
             elif isinstance(mutable, Iterable):
                 for m in mutable:
                     add_mutables_dfs(m)
-
+                    
         noncolcal_pars = inspect.getclosurevars(closure).nonlocals
         add_mutables_dfs(noncolcal_pars.values())
 

--- a/mmrazor/models/mutables/derived_mutable.py
+++ b/mmrazor/models/mutables/derived_mutable.py
@@ -370,7 +370,7 @@ class DerivedMutable(BaseMutable, DerivedMethodMixin):
             elif isinstance(mutable, Iterable):
                 for m in mutable:
                     add_mutables_dfs(m)
-                    
+
         noncolcal_pars = inspect.getclosurevars(closure).nonlocals
         add_mutables_dfs(noncolcal_pars.values())
 

--- a/mmrazor/models/mutables/mutable_channel/base_mutable_channel.py
+++ b/mmrazor/models/mutables/mutable_channel/base_mutable_channel.py
@@ -21,9 +21,9 @@ class BaseMutableChannel(BaseMutable, DerivedMethodMixin):
     |mutable_out_channel(BaseMutableChannel)|
     |---------------------------------------|
 
-    All subclasses should implement the following APIs:
+    All subclasses should implement the following APIs and the other
+    abstract method in ``BaseMutable``
 
-    - ``current_choice``
     - ``current_mask``
 
     Args:

--- a/mmrazor/models/mutables/mutable_channel/base_mutable_channel.py
+++ b/mmrazor/models/mutables/mutable_channel/base_mutable_channel.py
@@ -4,6 +4,7 @@ from abc import abstractmethod
 
 import torch
 
+from mmrazor.utils.typing import DumpChosen
 from ..base_mutable import BaseMutable
 from ..derived_mutable import DerivedMethodMixin
 
@@ -73,9 +74,15 @@ class BaseMutableChannel(BaseMutable, DerivedMethodMixin):
 
         self.is_fixed = True
 
-    def dump_chosen(self):
-        """dump current choice to a dict."""
-        raise NotImplementedError()
+    def dump_chosen(self) -> DumpChosen:
+        """Dump chosen."""
+        meta = dict(max_channels=self.mask.size(0))
+        chosen = self.export_chosen()
+
+        return DumpChosen(chosen=chosen, meta=meta)
+
+    def export_chosen(self) -> int:
+        return self.activated_channels
 
     def num_choices(self) -> int:
         """Number of available choices."""

--- a/mmrazor/models/mutables/mutable_channel/base_mutable_channel.py
+++ b/mmrazor/models/mutables/mutable_channel/base_mutable_channel.py
@@ -35,20 +35,6 @@ class BaseMutableChannel(BaseMutable, DerivedMethodMixin):
         self.name = ''
         self.num_channels = num_channels
 
-    # choice
-
-    @property  # type: ignore
-    @abstractmethod
-    def current_choice(self):
-        """get current choice."""
-        raise NotImplementedError()
-
-    @current_choice.setter  # type: ignore
-    @abstractmethod
-    def current_choice(self):
-        """set current choice."""
-        raise NotImplementedError()
-
     @property  # type: ignore
     @abstractmethod
     def current_mask(self) -> torch.Tensor:

--- a/mmrazor/models/mutables/mutable_channel/sequential_mutable_channel.py
+++ b/mmrazor/models/mutables/mutable_channel/sequential_mutable_channel.py
@@ -69,10 +69,6 @@ class SquentialMutableChannel(SimpleMutableChannel):
         self.current_choice = chosen
         self.is_fixed = True
 
-    def dump_chosen(self):
-        """Dump chosen."""
-        return self.current_choice
-
     def __rmul__(self, other) -> DerivedMutable:
         return self * other
 

--- a/mmrazor/models/mutables/mutable_channel/simple_mutable_channel.py
+++ b/mmrazor/models/mutables/mutable_channel/simple_mutable_channel.py
@@ -3,6 +3,7 @@
 import torch
 
 from mmrazor.registry import MODELS
+from mmrazor.utils.typing import DumpChosen
 from ..derived_mutable import DerivedMutable
 from .base_mutable_channel import BaseMutableChannel
 
@@ -36,6 +37,16 @@ class SimpleMutableChannel(BaseMutableChannel):
     def current_mask(self) -> torch.Tensor:
         """Get current mask."""
         return self.current_choice.bool()
+
+    def dump_chosen(self) -> DumpChosen:
+        """Dump chosen."""
+        meta = dict(max_channels=self.mask.size(0))
+        chosen = self.export_chosen()
+
+        return DumpChosen(chosen=chosen, meta=meta)
+
+    def export_chosen(self) -> int:
+        return self.activated_channels
 
     # basic extension
 

--- a/mmrazor/models/mutables/mutable_channel/simple_mutable_channel.py
+++ b/mmrazor/models/mutables/mutable_channel/simple_mutable_channel.py
@@ -3,7 +3,6 @@
 import torch
 
 from mmrazor.registry import MODELS
-from mmrazor.utils.typing import DumpChosen
 from ..derived_mutable import DerivedMutable
 from .base_mutable_channel import BaseMutableChannel
 
@@ -37,16 +36,6 @@ class SimpleMutableChannel(BaseMutableChannel):
     def current_mask(self) -> torch.Tensor:
         """Get current mask."""
         return self.current_choice.bool()
-
-    def dump_chosen(self) -> DumpChosen:
-        """Dump chosen."""
-        meta = dict(max_channels=self.mask.size(0))
-        chosen = self.export_chosen()
-
-        return DumpChosen(chosen=chosen, meta=meta)
-
-    def export_chosen(self) -> int:
-        return self.activated_channels
 
     # basic extension
 

--- a/mmrazor/models/mutables/mutable_channel/units/channel_unit.py
+++ b/mmrazor/models/mutables/mutable_channel/units/channel_unit.py
@@ -149,9 +149,10 @@ class ChannelUnit(BaseModule):
 
     def __init__(self, num_channels: int, **kwargs):
         super().__init__()
+        self.alias = None
         self.num_channels = num_channels
-        self.output_related: nn.ModuleList = nn.ModuleList()
-        self.input_related: nn.ModuleList = nn.ModuleList()
+        self.output_related: List[nn.Module] = list()
+        self.input_related: List[nn.Module] = list()
         self.init_args: Dict = {
         }  # is used to generate new channel unit with same args
 
@@ -208,14 +209,14 @@ class ChannelUnit(BaseModule):
 
         def init_from_base_channel_unit(base_channel_unit: BaseChannelUnit):
             unit = cls(len(base_channel_unit.channel_elems), **unit_args)
-            unit.input_related = nn.ModuleList([
+            unit.input_related = [
                 Channel.init_from_base_channel(channel)
                 for channel in base_channel_unit.input_related
-            ])
-            unit.output_related = nn.ModuleList([
+            ]
+            unit.output_related = [
                 Channel.init_from_base_channel(channel)
                 for channel in base_channel_unit.output_related
-            ])
+            ]
             return unit
 
         unit_graph = ChannelGraph.copy_from(graph,

--- a/mmrazor/models/mutables/mutable_channel/units/channel_unit.py
+++ b/mmrazor/models/mutables/mutable_channel/units/channel_unit.py
@@ -149,7 +149,7 @@ class ChannelUnit(BaseModule):
 
     def __init__(self, num_channels: int, **kwargs):
         super().__init__()
-        self.alias = None
+
         self.num_channels = num_channels
         self.output_related: List[nn.Module] = list()
         self.input_related: List[nn.Module] = list()
@@ -239,6 +239,11 @@ class ChannelUnit(BaseModule):
             first_module_name = 'unitx'
         name = f'{first_module_name}_{self.num_channels}'
         return name
+
+    @property
+    def alias(self) -> str:
+        """str: alias of the unit"""
+        return self.name
 
     def config_template(self,
                         with_init_args=False,

--- a/mmrazor/models/mutables/mutable_module/diff_mutable_module.py
+++ b/mmrazor/models/mutables/mutable_module/diff_mutable_module.py
@@ -1,7 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from abc import abstractmethod
 from functools import partial
-from typing import Any, Callable, Dict, Generic, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -10,13 +10,13 @@ from torch import Tensor
 
 from mmrazor.registry import MODELS
 from mmrazor.utils.typing import DumpChosen
-from ..base_mutable import Choice, Chosen
 from .mutable_module import MutableModule
 
 PartialType = Callable[[Any, Optional[nn.Parameter]], Any]
 
 
-class DiffMutableModule(MutableModule, Generic[Choice, Chosen]):
+class DiffMutableModule(
+        MutableModule, ):
     """Base class for differentiable mutables.
 
     Args:
@@ -88,7 +88,7 @@ class DiffMutableModule(MutableModule, Generic[Choice, Chosen]):
 
 
 @MODELS.register_module()
-class DiffMutableOP(DiffMutableModule[str, str]):
+class DiffMutableOP(DiffMutableModule):
     """A type of ``MUTABLES`` for differentiable architecture search, such as
     DARTS. Search the best module by learnable parameters `arch_param`.
 
@@ -342,7 +342,7 @@ class OneHotMutableOP(DiffMutableOP):
 
 
 @MODELS.register_module()
-class DiffChoiceRoute(DiffMutableModule[str, List[str]]):
+class DiffChoiceRoute(DiffMutableModule):
     """A type of ``MUTABLES`` for Neural Architecture Search, which can select
     inputs from different edges in a differentiable or non-differentiable way.
     It is commonly used in DARTS.

--- a/mmrazor/models/mutables/mutable_module/diff_mutable_module.py
+++ b/mmrazor/models/mutables/mutable_module/diff_mutable_module.py
@@ -15,8 +15,7 @@ from .mutable_module import MutableModule
 PartialType = Callable[[Any, Optional[nn.Parameter]], Any]
 
 
-class DiffMutableModule(
-        MutableModule, ):
+class DiffMutableModule(MutableModule):
     """Base class for differentiable mutables.
 
     Args:

--- a/mmrazor/models/mutables/mutable_module/mutable_module.py
+++ b/mmrazor/models/mutables/mutable_module/mutable_module.py
@@ -2,10 +2,10 @@
 from abc import abstractmethod
 from typing import Any, Dict, List, Optional
 
-from ..base_mutable import CHOICE_TYPE, CHOSEN_TYPE, BaseMutable
+from ..base_mutable import BaseMutable
 
 
-class MutableModule(BaseMutable[CHOICE_TYPE, CHOSEN_TYPE]):
+class MutableModule(BaseMutable):
     """Base Class for mutables. Mutable means a searchable module widely used
     in Neural Architecture Search(NAS).
 
@@ -34,10 +34,23 @@ class MutableModule(BaseMutable[CHOICE_TYPE, CHOSEN_TYPE]):
         super().__init__(**kwargs)
 
         self.module_kwargs = module_kwargs
+        self._current_choice = None
+
+    @property
+    def current_choice(self):
+        """Current choice will affect :meth:`forward` and will be used in
+        :func:`mmrazor.core.subnet.utils.export_fix_subnet` or mutator.
+        """
+        return self._current_choice
+
+    @current_choice.setter
+    def current_choice(self, choice) -> None:
+        """Current choice setter will be executed in mutator."""
+        self._current_choice = choice
 
     @property
     @abstractmethod
-    def choices(self) -> List[CHOICE_TYPE]:
+    def choices(self) -> List[str]:
         """list: all choices.  All subclasses must implement this method."""
 
     @abstractmethod

--- a/mmrazor/models/mutables/mutable_module/mutable_module.py
+++ b/mmrazor/models/mutables/mutable_module/mutable_module.py
@@ -1,11 +1,11 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from abc import abstractmethod
-from typing import Any, Dict, Generic, List, Optional
+from typing import Any, Dict, List, Optional
 
-from ..base_mutable import BaseMutable, Choice, Chosen
+from ..base_mutable import BaseMutable
 
 
-class MutableModule(BaseMutable, Generic[Choice, Chosen]):
+class MutableModule(BaseMutable):
     """Base Class for mutables. Mutable means a searchable module widely used
     in Neural Architecture Search(NAS).
 

--- a/mmrazor/models/mutables/mutable_module/mutable_module.py
+++ b/mmrazor/models/mutables/mutable_module/mutable_module.py
@@ -1,21 +1,21 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from abc import abstractmethod
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Generic, List, Optional
 
-from ..base_mutable import BaseMutable
+from ..base_mutable import BaseMutable, Choice, Chosen
 
 
-class MutableModule(BaseMutable):
+class MutableModule(BaseMutable, Generic[Choice, Chosen]):
     """Base Class for mutables. Mutable means a searchable module widely used
     in Neural Architecture Search(NAS).
 
     It mainly consists of some optional operations, and achieving
     searchable function by handling choice with ``MUTATOR``.
 
-    All subclass should implement the following APIs:
+    All subclass should implement the following APIs and the other
+    abstract method in ``BaseMutable``:
 
     - ``forward()``
-    - ``fix_chosen()``
     - ``choices()``
 
     Args:
@@ -56,6 +56,20 @@ class MutableModule(BaseMutable):
     @abstractmethod
     def forward(self, x: Any) -> Any:
         """Forward computation."""
+
+    @abstractmethod
+    def forward_fixed(self, x):
+        """Forward with the fixed mutable.
+
+        All subclasses must implement this method.
+        """
+
+    @abstractmethod
+    def forward_all(self, x):
+        """Forward all choices.
+
+        All subclasses must implement this method.
+        """
 
     @property
     def num_choices(self) -> int:

--- a/mmrazor/models/mutables/mutable_module/mutable_module.py
+++ b/mmrazor/models/mutables/mutable_module/mutable_module.py
@@ -16,6 +16,8 @@ class MutableModule(BaseMutable):
     abstract method in ``BaseMutable``:
 
     - ``forward()``
+    - ``forward_all()``
+    - ``forward_fix()``
     - ``choices()``
 
     Args:

--- a/mmrazor/models/mutables/mutable_module/mutable_module.py
+++ b/mmrazor/models/mutables/mutable_module/mutable_module.py
@@ -32,8 +32,9 @@ class MutableModule(BaseMutable):
 
     def __init__(self,
                  module_kwargs: Optional[Dict[str, Dict]] = None,
-                 **kwargs) -> None:
-        super().__init__(**kwargs)
+                 alias: Optional[str] = None,
+                 init_cfg: Optional[Dict] = None) -> None:
+        super().__init__(alias, init_cfg)
 
         self.module_kwargs = module_kwargs
         self._current_choice = None

--- a/mmrazor/models/mutables/mutable_module/one_shot_mutable_module.py
+++ b/mmrazor/models/mutables/mutable_module/one_shot_mutable_module.py
@@ -257,10 +257,6 @@ class OneShotMutableOP(OneShotMutableModule):
         """list: all choices. """
         return list(self._candidates.keys())
 
-    @property
-    def num_choices(self) -> int:
-        return len(self.choices)
-
 
 @MODELS.register_module()
 class OneShotProbMutableOP(OneShotMutableOP):

--- a/mmrazor/models/mutables/mutable_module/one_shot_mutable_module.py
+++ b/mmrazor/models/mutables/mutable_module/one_shot_mutable_module.py
@@ -16,11 +16,10 @@ class OneShotMutableModule(MutableModule):
     """Base class for one shot mutable module. A base type of ``MUTABLES`` for
     single path supernet such as Single Path One Shot.
 
-    All subclass should implement the following APIs:
+    All subclass should implement the following APIs and the other
+    abstract method in ``MutableModule``:
 
     - ``sample_choice()``
-    - ``forward_fixed()``
-    - ``forward_all()``
     - ``forward_choice()``
 
     Note:

--- a/mmrazor/models/mutables/mutable_module/one_shot_mutable_module.py
+++ b/mmrazor/models/mutables/mutable_module/one_shot_mutable_module.py
@@ -1,7 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import random
 from abc import abstractmethod
-from typing import Any, Dict, Generic, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
 import torch.nn as nn
@@ -9,11 +9,10 @@ from torch import Tensor
 
 from mmrazor.registry import MODELS
 from mmrazor.utils.typing import DumpChosen
-from ..base_mutable import Choice, Chosen
 from .mutable_module import MutableModule
 
 
-class OneShotMutableModule(MutableModule, Generic[Choice, Chosen]):
+class OneShotMutableModule(MutableModule):
     """Base class for one shot mutable module. A base type of ``MUTABLES`` for
     single path supernet such as Single Path One Shot.
 
@@ -71,7 +70,7 @@ class OneShotMutableModule(MutableModule, Generic[Choice, Chosen]):
 
 
 @MODELS.register_module()
-class OneShotMutableOP(OneShotMutableModule[str, str]):
+class OneShotMutableOP(OneShotMutableModule):
     """A type of ``MUTABLES`` for single path supernet, such as Single Path One
     Shot. In single path supernet, each choice block only has one choice
     invoked at the same time. A path is obtained by sampling all the choice
@@ -259,7 +258,7 @@ class OneShotMutableOP(OneShotMutableModule[str, str]):
         return list(self._candidates.keys())
 
     @property
-    def num_choices(self):
+    def num_choices(self) -> int:
         return len(self.choices)
 
 

--- a/mmrazor/models/mutables/mutable_value/mutable_value.py
+++ b/mmrazor/models/mutables/mutable_value/mutable_value.py
@@ -3,12 +3,13 @@ import random
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from mmrazor.registry import MODELS
+from mmrazor.utils.typing import DumpChosen
 from ..base_mutable import BaseMutable
 from ..derived_mutable import DerivedMethodMixin, DerivedMutable
 
 
 @MODELS.register_module()
-class MutableValue(BaseMutable[Any, Dict], DerivedMethodMixin):
+class MutableValue(BaseMutable, DerivedMethodMixin):
     """Base class for mutable value.
 
     A mutable value is actually a mutable that adds some functionality to a
@@ -68,24 +69,28 @@ class MutableValue(BaseMutable[Any, Dict], DerivedMethodMixin):
         if self.is_fixed:
             raise RuntimeError('MutableValue can not be fixed twice')
 
-        all_choices = chosen['all_choices']
-        current_choice = chosen['current_choice']
+        # all_choices = chosen['all_choices']
+        # current_choice = chosen['current_choice']
 
-        assert all_choices == self.choices, \
-            f'Expect choices to be: {self.choices}, but got: {all_choices}'
-        assert current_choice in self.choices
+        # assert all_choices == self.choices, \
+        #     f'Expect choices to be: {self.choices}, but got: {all_choices}'
+        assert chosen in self.choices
 
-        self.current_choice = current_choice
+        self.current_choice = chosen
         self.is_fixed = True
 
-    def dump_chosen(self) -> Dict[str, Any]:
+    def dump_chosen(self) -> DumpChosen:
         """Dump information of chosen.
 
         Returns:
             Dict[str, Any]: Dumped information.
         """
-        return dict(
-            current_choice=self.current_choice, all_choices=self.choices)
+        chosen = self.export_chosen()
+        meta = dict(all_choices=self.choices)
+        return DumpChosen(chosen=chosen, meta=meta)
+
+    def export_chosen(self):
+        return self.current_choice
 
     @property
     def num_choices(self) -> int:

--- a/mmrazor/models/mutables/mutable_value/mutable_value.py
+++ b/mmrazor/models/mutables/mutable_value/mutable_value.py
@@ -7,6 +7,8 @@ from mmrazor.utils.typing import DumpChosen
 from ..base_mutable import BaseMutable
 from ..derived_mutable import DerivedMethodMixin, DerivedMutable
 
+Value = Union[int, float]
+
 
 @MODELS.register_module()
 class MutableValue(BaseMutable, DerivedMethodMixin):
@@ -27,7 +29,7 @@ class MutableValue(BaseMutable, DerivedMethodMixin):
     """
 
     def __init__(self,
-                 value_list: List[Any],
+                 value_list: List[Value],
                  default_value: Optional[Any] = None,
                  alias: Optional[str] = None,
                  init_cfg: Optional[Dict] = None) -> None:
@@ -60,7 +62,7 @@ class MutableValue(BaseMutable, DerivedMethodMixin):
         """List of choices."""
         return self._value_list
 
-    def fix_chosen(self, chosen: Dict[str, Any]) -> None:
+    def fix_chosen(self, chosen: Value) -> None:
         """Fix mutable value with subnet config.
 
         Args:
@@ -69,11 +71,6 @@ class MutableValue(BaseMutable, DerivedMethodMixin):
         if self.is_fixed:
             raise RuntimeError('MutableValue can not be fixed twice')
 
-        # all_choices = chosen['all_choices']
-        # current_choice = chosen['current_choice']
-
-        # assert all_choices == self.choices, \
-        #     f'Expect choices to be: {self.choices}, but got: {all_choices}'
         assert chosen in self.choices
 
         self.current_choice = chosen

--- a/mmrazor/models/mutators/channel_mutator/channel_mutator.ipynb
+++ b/mmrazor/models/mutators/channel_mutator/channel_mutator.ipynb
@@ -25,7 +25,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -63,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
     {
@@ -116,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
@@ -175,7 +175,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
@@ -258,19 +258,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "{'net.conv0_(0, 8)_8': 8, 'net.conv1_(0, 16)_16': 16}\n"
+      "{0: 8, 1: 16}\n"
      ]
     }
    ],
    "source": [
-    "print(mutator.choice_template)"
+    "print(mutator.current_choices)"
    ]
   },
   {
@@ -282,7 +282,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
     {
@@ -296,14 +296,14 @@
       "      3, 8, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1)\n",
       "      (mutable_attrs): ModuleDict(\n",
       "        (in_channels): MutableChannelContainer(num_channels=3, activated_channels=3)\n",
-      "        (out_channels): MutableChannelContainer(num_channels=8, activated_channels=6)\n",
+      "        (out_channels): MutableChannelContainer(num_channels=8, activated_channels=4)\n",
       "      )\n",
       "    )\n",
       "    (relu): ReLU()\n",
       "    (conv1): DynamicConv2d(\n",
       "      8, 16, kernel_size=(3, 3), stride=(1, 1), padding=(1, 1)\n",
       "      (mutable_attrs): ModuleDict(\n",
-      "        (in_channels): MutableChannelContainer(num_channels=8, activated_channels=6)\n",
+      "        (in_channels): MutableChannelContainer(num_channels=8, activated_channels=4)\n",
       "        (out_channels): MutableChannelContainer(num_channels=16, activated_channels=8)\n",
       "      )\n",
       "    )\n",
@@ -322,7 +322,7 @@
    ],
    "source": [
     "mutator.set_choices(\n",
-    "    {'net.conv0_(0, 8)_8': 0.75, 'net.conv1_(0, 16)_16': 0.5}\n",
+    "    {0: 4, 1: 8}\n",
     ")\n",
     "print(model)"
    ]
@@ -337,7 +337,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.9.12 ('mmlab')",
+   "display_name": "Python 3.9.13 ('lab2max')",
    "language": "python",
    "name": "python3"
   },
@@ -351,12 +351,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.12"
+   "version": "3.9.13"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "feec882ee78c63cb8d4b485f1b52bbb873bb9a7b094435863200c7afba202382"
+    "hash": "e31a827d0913016ad78e01c7b97f787f4b9e53102dd62d238e8548bcd97ff875"
    }
   }
  },

--- a/mmrazor/models/mutators/channel_mutator/channel_mutator.py
+++ b/mmrazor/models/mutators/channel_mutator/channel_mutator.py
@@ -1,9 +1,9 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import copy
-from typing import Dict, Generic, List, Optional, Tuple, Type, Union
+from typing import Any, Dict, Generic, List, Optional, Tuple, Type, Union
 
 from mmengine import fileio
-from torch.nn import Module
+from torch.nn import Module, ModuleList
 
 from mmrazor.models.architectures.dynamic_ops import DynamicChannelMixin
 from mmrazor.models.mutables import (ChannelUnitType, MutableChannelUnit,
@@ -13,6 +13,7 @@ from mmrazor.models.mutables.mutable_channel.units.channel_unit import \
 from mmrazor.registry import MODELS
 from mmrazor.structures.graph import ModuleGraph
 from ..base_mutator import BaseMutator
+from ..group_mixin import GroupMixin
 
 
 def is_dynamic_op_for_fx_tracer(module, name):
@@ -20,7 +21,7 @@ def is_dynamic_op_for_fx_tracer(module, name):
 
 
 @MODELS.register_module()
-class ChannelMutator(BaseMutator, Generic[ChannelUnitType]):
+class ChannelMutator(BaseMutator, Generic[ChannelUnitType], GroupMixin):
     """ChannelMutator manages the pruning structure of a model.
 
     Args:
@@ -70,6 +71,7 @@ class ChannelMutator(BaseMutator, Generic[ChannelUnitType]):
                  parse_cfg: Dict = dict(
                      type='BackwardTracer',
                      loss_calculator=dict(type='ImageClassifierPseudoLoss')),
+                 custom_groups: Optional[List[List[str]]] = None,
                  init_cfg: Optional[Dict] = None) -> None:
 
         super().__init__(init_cfg)
@@ -83,13 +85,18 @@ class ChannelMutator(BaseMutator, Generic[ChannelUnitType]):
 
         # units
         self._name2unit: Dict[str, ChannelUnitType] = {}
-        self.units: List[ChannelUnitType] = []
+        self.units: ModuleList[ChannelUnitType] = ModuleList()
 
         # unit config
         self.channel_unit_cfg = channel_unit_cfg
         self.unit_class, self.unit_default_args, self.units_cfg = \
             self._parse_channel_unit_cfg(
                 channel_unit_cfg)
+
+        if custom_groups is None:
+            custom_groups = []
+        self._custom_groups = custom_groups
+        self._search_groups = None
 
     def prepare_from_supernet(self, supernet: Module) -> None:
         """Prepare from a model for pruning.
@@ -113,7 +120,11 @@ class ChannelMutator(BaseMutator, Generic[ChannelUnitType]):
         for unit in units:
             unit.prepare_for_pruning(supernet)
             self._name2unit[unit.name] = unit
-        self.units = units
+        self.units = ModuleList(units)
+
+        self._search_groups = self.build_search_groups(
+            ModuleList(self.mutable_units), self.mutable_class_type,
+            self._custom_groups)
 
     # ~
 
@@ -193,23 +204,40 @@ class ChannelMutator(BaseMutator, Generic[ChannelUnitType]):
     @property
     def current_choices(self) -> Dict:
         """Get current choices."""
-        config = self.choice_template
-        for unit in self.mutable_units:
-            config[unit.name] = unit.current_choice
-        return config
+        current_choices = dict()
+        for group_id, modules in self.search_groups.items():
+            current_choices[group_id] = modules[0].current_choice
 
-    def set_choices(self, config: Dict[str, Union[int, float]]):
-        """Set choices."""
-        for name, choice in config.items():
-            unit = self._name2unit[name]
-            unit.current_choice = choice
+        return current_choices
 
-    def sample_choices(self) -> Dict[str, Union[int, float]]:
-        """Sample choices(pruning structure)."""
-        template = self.choice_template
-        for key in template:
-            template[key] = self._name2unit[key].sample_choice()
-        return template
+    def sample_choices(self) -> Dict[int, Any]:
+        """Sampling by search groups.
+
+        The sampling result of the first mutable of each group is the sampling
+        result of this group.
+
+        Returns:
+            Dict[int, Any]: Random choices dict.
+        """
+        random_choices = dict()
+        for group_id, modules in self.search_groups.items():
+            random_choices[group_id] = modules[0].sample_choice()
+
+        return random_choices
+
+    def set_choices(self, choices: Dict[int, Any]) -> None:
+        """Set mutables' current choice according to choices sample by
+        :func:`sample_choices`.
+
+        Args:
+            choices (Dict[int, Any]): Choices dict. The key is group_id in
+                search groups, and the value is the sampling results
+                corresponding to this group.
+        """
+        for group_id, modules in self.search_groups.items():
+            choice = choices[group_id]
+            for module in modules:
+                module.current_choice = choice
 
     @property
     def choice_template(self) -> Dict:
@@ -227,10 +255,12 @@ class ChannelMutator(BaseMutator, Generic[ChannelUnitType]):
         return template
 
     # implementation of abstract functions
-
+    @property
     def search_groups(self) -> Dict:
-        return self._name2unit
 
+        return self._search_groups
+
+    @property
     def mutable_class_type(self) -> Type[ChannelUnitType]:
         return self.unit_class
 

--- a/mmrazor/models/mutators/channel_mutator/channel_mutator.py
+++ b/mmrazor/models/mutators/channel_mutator/channel_mutator.py
@@ -49,6 +49,10 @@ class ChannelMutator(BaseMutator, Generic[ChannelUnitType], GroupMixin):
                 dict( type='BackwardTracer',
                 loss_calculator=dict(type='ImageClassifierPseudoLoss')).
 
+        custom_groups (list[list[str]], optional): User-defined search groups.
+            All searchable modules that are not in ``custom_group`` will be
+            grouped separately.
+
         init_cfg (dict, optional): initialization configuration dict for
             BaseModule.
 

--- a/mmrazor/models/mutators/channel_mutator/channel_mutator.py
+++ b/mmrazor/models/mutators/channel_mutator/channel_mutator.py
@@ -253,14 +253,24 @@ class ChannelMutator(BaseMutator, Generic[ChannelUnitType], GroupMixin):
             template[unit.name] = unit.current_choice
         return template
 
-    # implementation of abstract functions
     @property
     def search_groups(self) -> Dict[int, List]:
+        """Search group of the supernet.
 
+        Note:
+            Search group is different from search space. The key of search
+            group is called ``group_id``, and the value is corresponding
+            searchable modules. The searchable modules will have the same
+            search space if they are in the same group.
+
+        Returns:
+            dict: Search group.
+        """
         return self._search_groups
 
     @property
     def mutable_class_type(self) -> Type[ChannelUnitType]:
+        """Mutable class type supported by this mutator."""
         return self.unit_class
 
     # private methods

--- a/mmrazor/models/mutators/channel_mutator/channel_mutator.py
+++ b/mmrazor/models/mutators/channel_mutator/channel_mutator.py
@@ -96,7 +96,6 @@ class ChannelMutator(BaseMutator, Generic[ChannelUnitType], GroupMixin):
         if custom_groups is None:
             custom_groups = []
         self._custom_groups = custom_groups
-        self._search_groups = None
 
     def prepare_from_supernet(self, supernet: Module) -> None:
         """Prepare from a model for pruning.
@@ -256,7 +255,7 @@ class ChannelMutator(BaseMutator, Generic[ChannelUnitType], GroupMixin):
 
     # implementation of abstract functions
     @property
-    def search_groups(self) -> Dict:
+    def search_groups(self) -> Dict[int, List]:
 
         return self._search_groups
 

--- a/mmrazor/models/mutators/channel_mutator/one_shot_channel_mutator.py
+++ b/mmrazor/models/mutators/channel_mutator/one_shot_channel_mutator.py
@@ -1,5 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from typing import Dict, Type, Union, Any
+from typing import Dict, Type, Union
 
 from mmrazor.models.mutables import OneShotMutableChannelUnit
 from mmrazor.registry import MODELS
@@ -41,5 +41,3 @@ class OneShotChannelMutator(ChannelMutator[OneShotMutableChannelUnit]):
             max_choices[group_id] = modules[0].max_choice
 
         return max_choices
-
-    

--- a/mmrazor/models/mutators/channel_mutator/one_shot_channel_mutator.py
+++ b/mmrazor/models/mutators/channel_mutator/one_shot_channel_mutator.py
@@ -1,5 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from typing import Dict, Type, Union
+from typing import Dict, Type, Union, Any
 
 from mmrazor.models.mutables import OneShotMutableChannelUnit
 from mmrazor.registry import MODELS
@@ -28,14 +28,18 @@ class OneShotChannelMutator(ChannelMutator[OneShotMutableChannelUnit]):
 
     def min_choices(self) -> Dict:
         """Return the minimal pruning subnet(structure)."""
-        template = self.choice_template
-        for key in template:
-            template[key] = self._name2unit[key].min_choice
-        return template
+        min_choices = dict()
+        for group_id, modules in self.search_groups.items():
+            min_choices[group_id] = modules[0].min_choice
+
+        return min_choices
 
     def max_choices(self) -> Dict:
         """Return the maximal pruning subnet(structure)."""
-        template = self.choice_template
-        for key in template:
-            template[key] = self._name2unit[key].max_choice
-        return template
+        max_choices = dict()
+        for group_id, modules in self.search_groups.items():
+            max_choices[group_id] = modules[0].max_choice
+
+        return max_choices
+
+    

--- a/mmrazor/models/mutators/channel_mutator/slimmable_channel_mutator.py
+++ b/mmrazor/models/mutators/channel_mutator/slimmable_channel_mutator.py
@@ -1,5 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from mmrazor.models.mutables import SlimmableChannelUnit
 from mmrazor.registry import MODELS
@@ -31,6 +31,16 @@ class SlimmableChannelMutator(ChannelMutator[SlimmableChannelUnit]):
         super().__init__(channel_unit_cfg, parse_cfg, init_cfg)
 
         self.subnets = self._prepare_subnets(self.units_cfg)
+
+    def set_choices(self, config: Dict[str, float]):
+        """Set choices."""
+        for name, choice in config.items():
+            unit = self._name2unit[name]
+            unit.current_choice = choice
+
+    def sample_choices(self) -> Dict[str, float]:
+        """Sample choices(pruning structure)."""
+        raise RuntimeError
 
     # private methods
 

--- a/mmrazor/models/mutators/channel_mutator/slimmable_channel_mutator.py
+++ b/mmrazor/models/mutators/channel_mutator/slimmable_channel_mutator.py
@@ -1,5 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Optional
 
 from mmrazor.models.mutables import SlimmableChannelUnit
 from mmrazor.registry import MODELS
@@ -28,17 +28,17 @@ class SlimmableChannelMutator(ChannelMutator[SlimmableChannelUnit]):
                      loss_calculator=dict(type='ImageClassifierPseudoLoss')),
                  init_cfg: Optional[Dict] = None) -> None:
 
-        super().__init__(channel_unit_cfg, parse_cfg, init_cfg)
+        super().__init__(channel_unit_cfg, parse_cfg, None, init_cfg)
 
         self.subnets = self._prepare_subnets(self.units_cfg)
 
-    def set_choices(self, config: Dict[str, float]):
+    def set_choices(self, config: Dict[str, float]):  # type: ignore[override]
         """Set choices."""
         for name, choice in config.items():
             unit = self._name2unit[name]
             unit.current_choice = choice
 
-    def sample_choices(self) -> Dict[str, float]:
+    def sample_choices(self):
         """Sample choices(pruning structure)."""
         raise RuntimeError
 

--- a/mmrazor/models/mutators/group_mixin.py
+++ b/mmrazor/models/mutators/group_mixin.py
@@ -1,0 +1,199 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+from abc import abstractmethod
+from collections import Counter
+from typing import Dict, List, Optional, Type
+
+from torch.nn import Module
+
+from .base_mutator import MUTABLE_TYPE, BaseMutator
+
+
+class GroupMixin():
+
+    def _build_name_mutable_mapping(
+            self, supernet: Module, support_mutables) -> Dict[str, MUTABLE_TYPE]:
+        """Mapping module name to mutable."""
+        name2mutable: Dict[str, MUTABLE_TYPE] = dict()
+        for name, module in supernet.named_modules():
+            if isinstance(module, support_mutables):
+                name2mutable[name] = module
+        self._name2mutable = name2mutable
+
+        return name2mutable
+
+    def _build_alias_names_mapping(self,
+                                   supernet: Module,
+                                   support_mutables) -> Dict[str, List[str]]:
+        """Mapping alias to module names."""
+        alias2mutable_names: Dict[str, List[str]] = dict()
+        for name, module in supernet.named_modules():
+            if isinstance(module, support_mutables):
+                if module.alias is not None:
+                    if module.alias not in alias2mutable_names:
+                        alias2mutable_names[module.alias] = [name]
+                    else:
+                        alias2mutable_names[module.alias].append(name)
+
+        return alias2mutable_names
+
+    def build_search_groups(self, supernet: Module, support_mutables, custom_groups) -> None:
+        """Build search group with ``custom_group`` and ``alias``(see more
+        information in :class:`BaseMutable`). Grouping by alias and module name
+        are both supported.
+
+        Note:
+            Apart from user-defined search group, all other searchable
+            modules(mutable) will be grouped separately.
+
+            The main difference between using alias and module name for
+            grouping is that the alias is One-to-Many while the module
+            name is One-to-One.
+
+            When using both alias and module name in `custom_group`, the
+            priority of alias is higher than that of module name.
+
+            If alias is set in `custom_group`, then its corresponding module
+            name should not be in the `custom_group`.
+
+            Moreover, there should be no duplicate keys in the `custom_group`.
+
+        Example:
+            >>> import torchBaseMutator
+
+            >>> # Using alias for grouping
+            >>> mutator = DiffMutableOP(custom_group=[['a1'], ['a2']])
+            >>> mutator.prepare_from_supernet(model)
+            >>> mutator.search_groups
+            {0: [op1, op2], 1: [op3]}
+
+            >>> # Using module name for grouping
+            >>> mutator = DiffMutableOP(custom_group=[['op1', 'op2'], ['op3']])
+            >>> mutator.prepare_from_supernet(model)
+            >>> mutator.search_groups
+            {0: [op1, op2], 1: [op3]}
+
+            >>> # Using both alias and module name for grouping
+            >>> mutator = DiffMutableOP(custom_group=[['a2'], ['op2']])
+            >>> mutator.prepare_from_supernet(model)
+            >>> # The last operation would be grouped
+            >>> mutator.search_groups
+            {0: [op3], 1: [op2], 2: [op1]}
+
+
+        Args:
+            supernet (:obj:`torch.nn.Module`): The supernet to be searched
+                in your algorithm.
+        """
+        name2mutable = self._build_name_mutable_mapping(supernet, support_mutables)
+        alias2mutable_names = self._build_alias_names_mapping(supernet, support_mutables)
+
+        # Check whether the custom group is valid
+        if len(custom_groups) > 0:
+            self._check_valid_groups(alias2mutable_names, name2mutable,
+                                     custom_groups)
+
+        # Construct search_groups based on user-defined group
+        search_groups: Dict[int, List[MUTABLE_TYPE]] = dict()
+
+        current_group_nums = 0
+        grouped_mutable_names: List[str] = list()
+        grouped_alias: List[str] = list()
+        for group in custom_groups:
+            group_mutables = list()
+            for item in group:
+                if item in alias2mutable_names:
+                    # if the item is from alias name
+                    mutable_names: List[str] = alias2mutable_names[item]
+                    grouped_alias.append(item)
+                    group_mutables.extend(
+                        [name2mutable[n] for n in mutable_names])
+                    grouped_mutable_names.extend(mutable_names)
+                else:
+                    # if the item is in name2mutable
+                    group_mutables.append(name2mutable[item])
+                    grouped_mutable_names.append(item)
+
+            search_groups[current_group_nums] = group_mutables
+            current_group_nums += 1
+
+        # Construct search_groups based on alias
+        for alias, mutable_names in alias2mutable_names.items():
+            if alias not in grouped_alias:
+                # Check whether all current names are already grouped
+                flag_all_grouped = True
+                for mutable_name in mutable_names:
+                    if mutable_name not in grouped_mutable_names:
+                        flag_all_grouped = False
+
+                # If not all mutables are already grouped
+                if not flag_all_grouped:
+                    search_groups[current_group_nums] = []
+                    for mutable_name in mutable_names:
+                        if mutable_name not in grouped_mutable_names:
+                            search_groups[current_group_nums].append(
+                                name2mutable[mutable_name])
+                            grouped_mutable_names.append(mutable_name)
+                    current_group_nums += 1
+
+        # check whether all the mutable objects are in the search_groups
+        for name, module in supernet.named_modules():
+            if isinstance(module, support_mutables):
+                if name in grouped_mutable_names:
+                    continue
+                else:
+                    search_groups[current_group_nums] = [module]
+                    current_group_nums += 1
+
+        grouped_counter = Counter(grouped_mutable_names)
+
+        # find duplicate keys
+        duplicate_keys = list()
+        for key, count in grouped_counter.items():
+            if count > 1:
+                duplicate_keys.append(key)
+
+        assert len(grouped_mutable_names) == len(
+            list(set(grouped_mutable_names))), \
+            'There are duplicate keys in grouped mutable names. ' \
+            f'The duplicate keys are {duplicate_keys}. ' \
+            'Please check if there are duplicate keys in the `custom_group`.'
+
+        return search_groups
+
+    def _check_valid_groups(self, alias2mutable_names: Dict[str, List[str]],
+                            name2mutable: Dict[str, MUTABLE_TYPE],
+                            custom_group: List[List[str]]) -> None:
+
+        aliases = [*alias2mutable_names.keys()]
+        module_names = [*name2mutable.keys()]
+
+        # check if all keys are legal
+        expanded_custom_group: List[str] = [
+            _ for group in custom_group for _ in group
+        ]
+        legal_keys: List[str] = [*aliases, *module_names]
+
+        for key in expanded_custom_group:
+            if key not in legal_keys:
+                raise AssertionError(
+                    f'The key: {key} in `custom_group` is not legal. '
+                    f'Legal keys are: {legal_keys}. '
+                    'Make sure that the keys are either alias or mutable name')
+
+        # when the mutable has alias attribute, the corresponding module
+        # name should not be used in `custom_group`.
+        used_aliases = list()
+        for group in custom_group:
+            for key in group:
+                if key in aliases:
+                    used_aliases.append(key)
+
+        for alias_key in used_aliases:
+            mutable_names: List = alias2mutable_names[alias_key]
+            # check whether module name is in custom group
+            for mutable_name in mutable_names:
+                if mutable_name in expanded_custom_group:
+                    raise AssertionError(
+                        f'When a mutable is set alias attribute :{alias_key},'
+                        f'the corresponding module name {mutable_name} should '
+                        f'not be used in `custom_group` {custom_group}.')

--- a/mmrazor/models/mutators/group_mixin.py
+++ b/mmrazor/models/mutators/group_mixin.py
@@ -9,6 +9,51 @@ from ..mutables import BaseMutable
 
 
 class GroupMixin():
+    """A mixin for :class:`ChannelMutator`, which can group mutables by
+    ``custom_group`` and ``alias``(see more information in
+    :class:`BaseMutable`). Grouping by alias and module name are both
+    supported.
+
+    Note:
+        Apart from user-defined search group, all other searchable
+        modules(mutable) will be grouped separately.
+
+        The main difference between using alias and module name for
+        grouping is that the alias is One-to-Many while the module
+        name is One-to-One.
+
+        When using both alias and module name in `custom_group`, the
+        priority of alias is higher than that of module name.
+
+        If alias is set in `custom_group`, then its corresponding module
+        name should not be in the `custom_group`.
+
+        Moreover, there should be no duplicate keys in the `custom_group`.
+
+    Example:
+        >>> import torch
+        >>> from mmrazor.models import DiffModuleMutator
+
+        >>> # Using alias for grouping
+        >>> mutator = DiffModuleMutator(custom_group=[['a1'], ['a2']])
+        >>> mutator.prepare_from_supernet(model)
+        >>> mutator.search_groups
+        {0: [op1, op2], 1: [op3]}
+
+        >>> # Using module name for grouping
+        >>> mutator = DiffModuleMutator(custom_group=[['op1', 'op2'], ['op3']])
+        >>> mutator.prepare_from_supernet(model)
+        >>> mutator.search_groups
+        {0: [op1, op2], 1: [op3]}
+
+        >>> # Using both alias and module name for grouping
+        >>> mutator = DiffModuleMutator(custom_group=[['a2'], ['op2']])
+        >>> mutator.prepare_from_supernet(model)
+        >>> # The last operation would be grouped
+        >>> mutator.search_groups
+        {0: [op3], 1: [op2], 2: [op1]}
+
+    """
 
     def _build_name_mutable_mapping(
             self, supernet: Module,
@@ -44,48 +89,13 @@ class GroupMixin():
         information in :class:`BaseMutable`). Grouping by alias and module name
         are both supported.
 
-        Note:
-            Apart from user-defined search group, all other searchable
-            modules(mutable) will be grouped separately.
-
-            The main difference between using alias and module name for
-            grouping is that the alias is One-to-Many while the module
-            name is One-to-One.
-
-            When using both alias and module name in `custom_group`, the
-            priority of alias is higher than that of module name.
-
-            If alias is set in `custom_group`, then its corresponding module
-            name should not be in the `custom_group`.
-
-            Moreover, there should be no duplicate keys in the `custom_group`.
-
-        Example:
-            >>> import torchBaseMutator
-
-            >>> # Using alias for grouping
-            >>> mutator = DiffMutableOP(custom_group=[['a1'], ['a2']])
-            >>> mutator.prepare_from_supernet(model)
-            >>> mutator.search_groups
-            {0: [op1, op2], 1: [op3]}
-
-            >>> # Using module name for grouping
-            >>> mutator = DiffMutableOP(custom_group=[['op1', 'op2'], ['op3']])
-            >>> mutator.prepare_from_supernet(model)
-            >>> mutator.search_groups
-            {0: [op1, op2], 1: [op3]}
-
-            >>> # Using both alias and module name for grouping
-            >>> mutator = DiffMutableOP(custom_group=[['a2'], ['op2']])
-            >>> mutator.prepare_from_supernet(model)
-            >>> # The last operation would be grouped
-            >>> mutator.search_groups
-            {0: [op3], 1: [op2], 2: [op1]}
-
-
         Args:
             supernet (:obj:`torch.nn.Module`): The supernet to be searched
                 in your algorithm.
+            support_mutables (Type): Mutable type that can be grouped.
+            custom_group (list, optional): User-defined search groups.
+                All searchable modules that are not in ``custom_group`` will be
+                grouped separately.
         """
         name2mutable: Dict[str,
                            BaseMutable] = self._build_name_mutable_mapping(

--- a/mmrazor/models/mutators/group_mixin.py
+++ b/mmrazor/models/mutators/group_mixin.py
@@ -9,7 +9,7 @@ from ..mutables import BaseMutable
 
 
 class GroupMixin():
-    """A mixin for :class:`ChannelMutator`, which can group mutables by
+    """A mixin for :class:`BaseMutator`, which can group mutables by
     ``custom_group`` and ``alias``(see more information in
     :class:`BaseMutable`). Grouping by alias and module name are both
     supported.
@@ -34,6 +34,11 @@ class GroupMixin():
         >>> import torch
         >>> from mmrazor.models import DiffModuleMutator
 
+        >>> # Assume that a toy model consists of three mutables
+        >>> # whose name are op1,op2,op3. The corresponding
+        >>> # alias names of the three mutables are a1, a1, a2.
+        >>> model = ToyModel()
+
         >>> # Using alias for grouping
         >>> mutator = DiffModuleMutator(custom_group=[['a1'], ['a2']])
         >>> mutator.prepare_from_supernet(model)
@@ -42,6 +47,8 @@ class GroupMixin():
 
         >>> # Using module name for grouping
         >>> mutator = DiffModuleMutator(custom_group=[['op1', 'op2'], ['op3']])
+
+        >>> # Using module name for grouping
         >>> mutator.prepare_from_supernet(model)
         >>> mutator.search_groups
         {0: [op1, op2], 1: [op3]}

--- a/mmrazor/models/mutators/module_mutator/diff_module_mutator.py
+++ b/mmrazor/models/mutators/module_mutator/diff_module_mutator.py
@@ -25,9 +25,9 @@ class DiffModuleMutator(ModuleMutator):
     """
 
     def __init__(self,
-                 custom_group: Optional[List[List[str]]] = None,
+                 custom_groups: Optional[List[List[str]]] = None,
                  init_cfg: Optional[Dict] = None) -> None:
-        super().__init__(custom_group=custom_group, init_cfg=init_cfg)
+        super().__init__(custom_groups=custom_groups, init_cfg=init_cfg)
 
     def build_arch_param(self, num_choices) -> nn.Parameter:
         """Build learnable architecture parameters."""

--- a/mmrazor/models/mutators/module_mutator/module_mutator.py
+++ b/mmrazor/models/mutators/module_mutator/module_mutator.py
@@ -16,19 +16,19 @@ class ModuleMutator(BaseMutator[MUTABLE_TYPE], GroupMixin):
     - ``mutable_class_type``
 
     Args:
-        custom_group (list[list[str]], optional): User-defined search groups.
+        custom_groups (list[list[str]], optional): User-defined search groups.
             All searchable modules that are not in ``custom_group`` will be
             grouped separately.
     """
 
     def __init__(self,
-                 custom_group: Optional[List[List[str]]] = None,
+                 custom_groups: Optional[List[List[str]]] = None,
                  init_cfg: Optional[Dict] = None) -> None:
         super().__init__(init_cfg)
 
-        if custom_group is None:
-            custom_group = []
-        self._custom_group = custom_group
+        if custom_groups is None:
+            custom_groups = []
+        self._custom_groups = custom_groups
         self._search_groups: Optional[Dict[int, List[MUTABLE_TYPE]]] = None
 
     # TODO
@@ -54,7 +54,7 @@ class ModuleMutator(BaseMutator[MUTABLE_TYPE], GroupMixin):
         """
         self._search_groups = self.build_search_groups(supernet,
                                                        self.mutable_class_type,
-                                                       self._custom_group)
+                                                       self._custom_groups)
 
     @property
     def name2mutable(self) -> Dict[str, MUTABLE_TYPE]:

--- a/mmrazor/models/mutators/module_mutator/module_mutator.py
+++ b/mmrazor/models/mutators/module_mutator/module_mutator.py
@@ -6,9 +6,10 @@ from typing import Dict, List, Optional, Type
 from torch.nn import Module
 
 from ..base_mutator import MUTABLE_TYPE, BaseMutator
+from ..group_mixin import GroupMixin
 
 
-class ModuleMutator(BaseMutator[MUTABLE_TYPE]):
+class ModuleMutator(BaseMutator[MUTABLE_TYPE], GroupMixin):
     """The base class for mutable based mutator.
 
     All subclass should implement the following APIS:
@@ -52,7 +53,9 @@ class ModuleMutator(BaseMutator[MUTABLE_TYPE]):
             supernet (:obj:`torch.nn.Module`): The supernet to be searched
                 in your algorithm.
         """
-        self._build_search_groups(supernet)
+        self._search_groups = self.build_search_groups(supernet,
+                                                       self.mutable_class_type,
+                                                       self._custom_group)
 
     @property
     def name2mutable(self) -> Dict[str, MUTABLE_TYPE]:
@@ -90,196 +93,3 @@ class ModuleMutator(BaseMutator[MUTABLE_TYPE]):
             raise RuntimeError(
                 'Call `prepare_from_supernet` before access search group!')
         return self._search_groups
-
-    def _build_name_mutable_mapping(
-            self, supernet: Module) -> Dict[str, MUTABLE_TYPE]:
-        """Mapping module name to mutable."""
-        name2mutable: Dict[str, MUTABLE_TYPE] = dict()
-        for name, module in supernet.named_modules():
-            if isinstance(module, self.mutable_class_type):
-                name2mutable[name] = module
-        self._name2mutable = name2mutable
-
-        return name2mutable
-
-    def _build_alias_names_mapping(self,
-                                   supernet: Module) -> Dict[str, List[str]]:
-        """Mapping alias to module names."""
-        alias2mutable_names: Dict[str, List[str]] = dict()
-        for name, module in supernet.named_modules():
-            if isinstance(module, self.mutable_class_type):
-                if module.alias is not None:
-                    if module.alias not in alias2mutable_names:
-                        alias2mutable_names[module.alias] = [name]
-                    else:
-                        alias2mutable_names[module.alias].append(name)
-
-        return alias2mutable_names
-
-    def _build_search_groups(self, supernet: Module) -> None:
-        """Build search group with ``custom_group`` and ``alias``(see more
-        information in :class:`BaseMutable`). Grouping by alias and module name
-        are both supported.
-
-        Note:
-            Apart from user-defined search group, all other searchable
-            modules(mutable) will be grouped separately.
-
-            The main difference between using alias and module name for
-            grouping is that the alias is One-to-Many while the module
-            name is One-to-One.
-
-            When using both alias and module name in `custom_group`, the
-            priority of alias is higher than that of module name.
-
-            If alias is set in `custom_group`, then its corresponding module
-            name should not be in the `custom_group`.
-
-            Moreover, there should be no duplicate keys in the `custom_group`.
-
-        Example:
-            >>> import torch
-            >>> from mmrazor.models.mutables.diff_mutable import DiffMutableOP
-
-            >>> # Assume that a toy model consists of three mutables
-            >>> # whose name are op1,op2,op3. The corresponding
-            >>> # alias names of the three mutables are a1, a1, a2.
-            >>> model = ToyModel()
-
-            >>> # Using alias for grouping
-            >>> mutator = DiffMutableOP(custom_group=[['a1'], ['a2']])
-            >>> mutator.prepare_from_supernet(model)
-            >>> mutator.search_groups
-            {0: [op1, op2], 1: [op3]}
-
-            >>> # Using module name for grouping
-            >>> mutator = DiffMutableOP(custom_group=[['op1', 'op2'], ['op3']])
-            >>> mutator.prepare_from_supernet(model)
-            >>> mutator.search_groups
-            {0: [op1, op2], 1: [op3]}
-
-            >>> # Using both alias and module name for grouping
-            >>> mutator = DiffMutableOP(custom_group=[['a2'], ['op2']])
-            >>> mutator.prepare_from_supernet(model)
-            >>> # The last operation would be grouped
-            >>> mutator.search_groups
-            {0: [op3], 1: [op2], 2: [op1]}
-
-
-        Args:
-            supernet (:obj:`torch.nn.Module`): The supernet to be searched
-                in your algorithm.
-        """
-        name2mutable = self._build_name_mutable_mapping(supernet)
-        alias2mutable_names = self._build_alias_names_mapping(supernet)
-
-        # Check whether the custom group is valid
-        if len(self._custom_group) > 0:
-            self._check_valid_groups(alias2mutable_names, name2mutable,
-                                     self._custom_group)
-
-        # Construct search_groups based on user-defined group
-        search_groups: Dict[int, List[MUTABLE_TYPE]] = dict()
-
-        current_group_nums = 0
-        grouped_mutable_names: List[str] = list()
-        grouped_alias: List[str] = list()
-        for group in self._custom_group:
-            group_mutables = list()
-            for item in group:
-                if item in alias2mutable_names:
-                    # if the item is from alias name
-                    mutable_names: List[str] = alias2mutable_names[item]
-                    grouped_alias.append(item)
-                    group_mutables.extend(
-                        [name2mutable[n] for n in mutable_names])
-                    grouped_mutable_names.extend(mutable_names)
-                else:
-                    # if the item is in name2mutable
-                    group_mutables.append(name2mutable[item])
-                    grouped_mutable_names.append(item)
-
-            search_groups[current_group_nums] = group_mutables
-            current_group_nums += 1
-
-        # Construct search_groups based on alias
-        for alias, mutable_names in alias2mutable_names.items():
-            if alias not in grouped_alias:
-                # Check whether all current names are already grouped
-                flag_all_grouped = True
-                for mutable_name in mutable_names:
-                    if mutable_name not in grouped_mutable_names:
-                        flag_all_grouped = False
-
-                # If not all mutables are already grouped
-                if not flag_all_grouped:
-                    search_groups[current_group_nums] = []
-                    for mutable_name in mutable_names:
-                        if mutable_name not in grouped_mutable_names:
-                            search_groups[current_group_nums].append(
-                                name2mutable[mutable_name])
-                            grouped_mutable_names.append(mutable_name)
-                    current_group_nums += 1
-
-        # check whether all the mutable objects are in the search_groups
-        for name, module in supernet.named_modules():
-            if isinstance(module, self.mutable_class_type):
-                if name in grouped_mutable_names:
-                    continue
-                else:
-                    search_groups[current_group_nums] = [module]
-                    current_group_nums += 1
-
-        grouped_counter = Counter(grouped_mutable_names)
-
-        # find duplicate keys
-        duplicate_keys = list()
-        for key, count in grouped_counter.items():
-            if count > 1:
-                duplicate_keys.append(key)
-
-        assert len(grouped_mutable_names) == len(
-            list(set(grouped_mutable_names))), \
-            'There are duplicate keys in grouped mutable names. ' \
-            f'The duplicate keys are {duplicate_keys}. ' \
-            'Please check if there are duplicate keys in the `custom_group`.'
-
-        self._search_groups = search_groups
-
-    def _check_valid_groups(self, alias2mutable_names: Dict[str, List[str]],
-                            name2mutable: Dict[str, MUTABLE_TYPE],
-                            custom_group: List[List[str]]) -> None:
-
-        aliases = [*alias2mutable_names.keys()]
-        module_names = [*name2mutable.keys()]
-
-        # check if all keys are legal
-        expanded_custom_group: List[str] = [
-            _ for group in custom_group for _ in group
-        ]
-        legal_keys: List[str] = [*aliases, *module_names]
-
-        for key in expanded_custom_group:
-            if key not in legal_keys:
-                raise AssertionError(
-                    f'The key: {key} in `custom_group` is not legal. '
-                    f'Legal keys are: {legal_keys}. '
-                    'Make sure that the keys are either alias or mutable name')
-
-        # when the mutable has alias attribute, the corresponding module
-        # name should not be used in `custom_group`.
-        used_aliases = list()
-        for group in custom_group:
-            for key in group:
-                if key in aliases:
-                    used_aliases.append(key)
-
-        for alias_key in used_aliases:
-            mutable_names: List = alias2mutable_names[alias_key]
-            # check whether module name is in custom group
-            for mutable_name in mutable_names:
-                if mutable_name in expanded_custom_group:
-                    raise AssertionError(
-                        f'When a mutable is set alias attribute :{alias_key},'
-                        f'the corresponding module name {mutable_name} should '
-                        f'not be used in `custom_group` {custom_group}.')

--- a/mmrazor/models/mutators/module_mutator/module_mutator.py
+++ b/mmrazor/models/mutators/module_mutator/module_mutator.py
@@ -1,6 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from abc import abstractmethod
-from collections import Counter
 from typing import Dict, List, Optional, Type
 
 from torch.nn import Module

--- a/mmrazor/structures/subnet/fix_subnet.py
+++ b/mmrazor/structures/subnet/fix_subnet.py
@@ -6,6 +6,7 @@ from mmengine.logging import print_log
 from torch import nn
 
 from mmrazor.utils import FixMutable, ValidFixMutable
+from mmrazor.utils.typing import DumpChosen
 
 
 def _dynamic_to_static(model: nn.Module) -> None:
@@ -56,6 +57,7 @@ def load_fix_subnet(model: nn.Module,
                     assert alias in fix_mutable, \
                         f'The alias {alias} is not in fix_modules, ' \
                         'please check your `fix_mutable`.'
+                    # {chosen=xx, meta=xx)
                     chosen = fix_mutable.get(alias, None)
                 else:
                     mutable_name = name.lstrip(prefix)
@@ -64,8 +66,12 @@ def load_fix_subnet(model: nn.Module,
                         raise RuntimeError(
                             f'The module name {mutable_name} is not in '
                             'fix_mutable, please check your `fix_mutable`.')
+                    # {chosen=xx, meta=xx)
                     chosen = fix_mutable.get(mutable_name, None)
-                module.fix_chosen(chosen)
+
+                if not isinstance(chosen, DumpChosen):
+                    chosen = DumpChosen(**chosen)
+                module.fix_chosen(chosen.chosen)
 
     # convert dynamic op to static op
     _dynamic_to_static(model)

--- a/mmrazor/utils/typing.py
+++ b/mmrazor/utils/typing.py
@@ -1,6 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from pathlib import Path
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, NamedTuple, Optional, Union
 
 FixMutable = Dict[str, Any]
 ValidFixMutable = Union[str, Path, FixMutable]
@@ -23,3 +23,15 @@ MultiMutatorsRandomSubnet = List[SingleMutatorRandomSubnet]
 
 SupportRandomSubnet = Union[SingleMutatorRandomSubnet,
                             MultiMutatorsRandomSubnet]
+
+Chosen = Union[str, float, List[str]]
+ChosenMeta = Optional[Dict[str, Any]]
+
+
+class DumpChosen(NamedTuple):
+    chosen: Chosen
+    meta: ChosenMeta = None
+
+
+# DumpChosen = NamedTuple('DumpChosen', [('chosen', Chosen),
+#                                        ('meta', ChosenMeta)])

--- a/tests/data/models.py
+++ b/tests/data/models.py
@@ -513,6 +513,9 @@ class SampleExpandDerivedMutable(BaseMutable):
     def dump_chosen(self):
         return super().dump_chosen()
 
+    def export_chosen(self):
+        return super().export_chosen()
+
     def fix_chosen(self, chosen):
         return super().fix_chosen(chosen)
 

--- a/tests/data/models.py
+++ b/tests/data/models.py
@@ -522,6 +522,16 @@ class SampleExpandDerivedMutable(BaseMutable):
     def num_choices(self) -> int:
         return super().num_choices
 
+    @property
+    def current_choice(self):
+        return super().current_choice
+
+    @current_choice.setter
+    def current_choice(self, choice):
+        super().current_choice(choice)
+
+    
+
 
 class DynamicLinearModel(nn.Module):
     """

--- a/tests/data/test_models/test_subnet/mockmodel_subnet.yaml
+++ b/tests/data/test_models/test_subnet/mockmodel_subnet.yaml
@@ -1,2 +1,4 @@
-mutable1: conv1
-mutable2: conv2
+mutable1: 
+  chosen: conv1
+mutable2: 
+  chosen: conv2

--- a/tests/data/test_registry/registry_subnet_config.py
+++ b/tests/data/test_registry/registry_subnet_config.py
@@ -7,7 +7,7 @@ model = dict(
     type='MockAlgorithm',
     architecture=supernet,
     _fix_subnet_ = {
-            'architecture.mutable1': 'conv1',
-            'architecture.mutable2': 'conv2',
+            'architecture.mutable1': {'chosen':'conv1'},
+            'architecture.mutable2': {'chosen':'conv2'},
         }
 )

--- a/tests/test_models/test_algorithms/test_darts.py
+++ b/tests/test_models/test_algorithms/test_darts.py
@@ -104,7 +104,11 @@ class TestDarts(TestCase):
         self.assertIsInstance(algo.mutator, DiffModuleMutator)
 
         # initiate darts when `fix_subnet` is not None
-        fix_subnet = {'normal': ['torch_conv2d_3x3', 'torch_conv2d_7x7']}
+        fix_subnet = {
+            'normal': {
+                'chosen': ['torch_conv2d_3x3', 'torch_conv2d_7x7']
+            }
+        }
         algo = Darts(model, mutator, fix_subnet=fix_subnet)
         self.assertEqual(algo.architecture.mutable.num_choices, 2)
 
@@ -124,7 +128,11 @@ class TestDarts(TestCase):
         self.assertIsInstance(loss, dict)
 
         # subnet
-        fix_subnet = {'normal': ['torch_conv2d_3x3', 'torch_conv2d_7x7']}
+        fix_subnet = {
+            'normal': {
+                'chosen': ['torch_conv2d_3x3', 'torch_conv2d_7x7']
+            }
+        }
         algo = Darts(model, fix_subnet=fix_subnet)
         loss = algo(inputs, mode='loss')
         self.assertIsInstance(loss, dict)

--- a/tests/test_models/test_algorithms/test_dsnas.py
+++ b/tests/test_models/test_algorithms/test_dsnas.py
@@ -97,7 +97,7 @@ class TestDsnas(TestCase):
         self.assertIsInstance(algo.mutator, DiffModuleMutator)
 
         # initiate Dsnas when `fix_subnet` is not None
-        fix_subnet = {'mutable': 'torch_conv2d_5x5'}
+        fix_subnet = {'mutable': {'chosen': 'torch_conv2d_5x5'}}
         algo = Dsnas(model, mutator, fix_subnet=fix_subnet)
         self.assertEqual(algo.architecture.mutable.num_choices, 1)
 
@@ -117,7 +117,7 @@ class TestDsnas(TestCase):
         self.assertIsInstance(loss, dict)
 
         # subnet
-        fix_subnet = {'mutable': 'torch_conv2d_5x5'}
+        fix_subnet = {'mutable': {'chosen': 'torch_conv2d_5x5'}}
         algo = Dsnas(model, fix_subnet=fix_subnet)
         loss = algo(inputs, mode='loss')
         self.assertIsInstance(loss, dict)

--- a/tests/test_models/test_algorithms/test_prune_algorithm.py
+++ b/tests/test_models/test_algorithms/test_prune_algorithm.py
@@ -114,7 +114,8 @@ class TestItePruneAlgorithm(unittest.TestCase):
         model = MODELS.build(MODEL_CFG)
         mutator = MODELS.build(MUTATOR_CONFIG_FLOAT)
         mutator.prepare_from_supernet(model)
-        prune_target = mutator.sample_choices()
+        mutator.set_choices(mutator.sample_choices())
+        prune_target = mutator.choice_template
 
         epoch = 10
         epoch_step = 2
@@ -135,9 +136,11 @@ class TestItePruneAlgorithm(unittest.TestCase):
                     data['inputs'], data['data_samples'], mode='loss')
 
         current_choices = algorithm.mutator.current_choices
+        group_prune_target = algorithm.group_target_pruning_ratio(
+            prune_target, mutator.search_groups)
         for key in current_choices:
             self.assertAlmostEqual(
-                current_choices[key], prune_target[key], delta=0.1)
+                current_choices[key], group_prune_target[key], delta=0.1)
 
     def test_load_pretrained(self):
         epoch_step = 2
@@ -158,7 +161,7 @@ class TestItePruneAlgorithm(unittest.TestCase):
         algorithm = ItePruneAlgorithm(
             model_cfg,
             mutator_cfg=MUTATOR_CONFIG_NUM,
-            target_pruning_ratio={},
+            target_pruning_ratio=None,
             step_epoch=epoch_step,
             prune_times=times,
         ).to(DEVICE)

--- a/tests/test_models/test_algorithms/test_spos.py
+++ b/tests/test_models/test_algorithms/test_spos.py
@@ -56,7 +56,7 @@ class TestSPOS(TestCase):
         self.assertIsInstance(alg.mutator, OneShotModuleMutator)
 
         # initiate spos when `fix_subnet` is not None.
-        fix_subnet = {'mutable': 'conv1'}
+        fix_subnet = {'mutable': {'chosen': 'conv1'}}
         alg = SPOS(model, mutator, fix_subnet=fix_subnet)
         self.assertEqual(alg.architecture.mutable.num_choices, 1)
 
@@ -75,7 +75,7 @@ class TestSPOS(TestCase):
         self.assertIsInstance(loss, dict)
 
         # subnet
-        fix_subnet = {'mutable': 'conv1'}
+        fix_subnet = {'mutable': {'chosen': 'conv1'}}
         alg = SPOS(model, fix_subnet=fix_subnet)
         loss = alg(inputs, mode='loss')
         self.assertIsInstance(loss, dict)

--- a/tests/test_models/test_architectures/test_backbones/test_dartsbackbone.py
+++ b/tests/test_models/test_architectures/test_backbones/test_dartsbackbone.py
@@ -55,7 +55,7 @@ class TestDartsBackbone(TestCase):
 
         self.mutator_cfg = dict(
             type='DiffModuleMutator',
-            custom_group=None,
+            custom_groups=None,
         )
 
     def test_darts_backbone(self):
@@ -81,7 +81,7 @@ class TestDartsBackbone(TestCase):
         custom_group = self.generate_key(model)
 
         assert model is not None
-        self.mutable_cfg.update(custom_group=custom_group)
+        self.mutable_cfg.update(custom_groups=custom_group)
         mutator = MODELS.build(self.mutator_cfg)
         assert mutator is not None
         mutator.prepare_from_supernet(model)

--- a/tests/test_models/test_architectures/test_dynamic_op/utils.py
+++ b/tests/test_models/test_architectures/test_dynamic_op/utils.py
@@ -2,6 +2,7 @@
 from typing import Dict, Optional
 
 from mmrazor.models.architectures.dynamic_ops import DynamicMixin
+from mmrazor.utils.typing import DumpChosen
 
 
 def fix_dynamic_op(op: DynamicMixin,
@@ -13,4 +14,7 @@ def fix_dynamic_op(op: DynamicMixin,
         else:
             chosen = mutable.dump_chosen()
 
-        mutable.fix_chosen(chosen)
+        if not isinstance(chosen, DumpChosen):
+            chosen = DumpChosen(**chosen)
+
+        mutable.fix_chosen(chosen.chosen)

--- a/tests/test_models/test_mutables/test_derived_mutable.py
+++ b/tests/test_models/test_mutables/test_derived_mutable.py
@@ -24,9 +24,9 @@ class TestDerivedMutable(TestCase):
         with pytest.raises(RuntimeError):
             derived_mutable.is_fixed = True
 
-        mc.fix_chosen(mc.dump_chosen())
+        mc.fix_chosen(mc.dump_chosen().chosen)
         assert not derived_mutable.is_fixed
-        mv.fix_chosen(mv.dump_chosen())
+        mv.fix_chosen(mv.dump_chosen().chosen)
         assert derived_mutable.is_fixed
 
     def test_fix_dump_chosen(self) -> None:
@@ -34,13 +34,13 @@ class TestDerivedMutable(TestCase):
         mv.current_choice = 3
 
         derived_mutable = mv * 2
-        assert derived_mutable.dump_chosen() == 6
+        assert derived_mutable.dump_chosen().chosen == 6
 
         mv.current_choice = 4
-        assert derived_mutable.dump_chosen() == 8
+        assert derived_mutable.dump_chosen().chosen == 8
 
         # nothing will happen
-        derived_mutable.fix_chosen(derived_mutable.dump_chosen())
+        derived_mutable.fix_chosen(derived_mutable.dump_chosen().chosen)
 
     def test_derived_same_mutable(self) -> None:
         mc = SquentialMutableChannel(num_channels=3)

--- a/tests/test_models/test_mutables/test_diffop.py
+++ b/tests/test_models/test_mutables/test_diffop.py
@@ -44,9 +44,6 @@ class TestDiffOP(TestCase):
         output = op.forward_arch_param(input, arch_param=arch_param)
         assert output is not None
 
-        output = op.forward_arch_param(input, arch_param=None)
-        assert output is not None
-
         # test when some element of arch_param is 0
         arch_param = nn.Parameter(torch.ones(op.num_choices))
         output = op.forward_arch_param(input, arch_param=arch_param)

--- a/tests/test_models/test_mutables/test_mutable_channel/test_mutable_channels.py
+++ b/tests/test_models/test_mutables/test_mutable_channel/test_mutable_channels.py
@@ -1,7 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import unittest
 
-import pytest
 import torch
 
 from mmrazor.models.mutables import (SimpleMutableChannel,
@@ -31,5 +30,5 @@ class TestMutableChannels(unittest.TestCase):
         channel.current_choice = torch.tensor([1, 0, 0, 0]).bool()
         self.assertEqual(channel.activated_channels, 1)
         channel.fix_chosen()
-        with pytest.raises(NotImplementedError):
-            channel.dump_chosen()
+        # with pytest.raises(NotImplementedError):
+        #     channel.dump_chosen()

--- a/tests/test_models/test_mutables/test_mutable_value.py
+++ b/tests/test_models/test_mutables/test_mutable_value.py
@@ -1,5 +1,4 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-import copy
 from unittest import TestCase
 
 import pytest
@@ -42,22 +41,18 @@ class TestMutableValue(TestCase):
     def test_fix_chosen(self) -> None:
         mv = MutableValue([2, 3, 4])
         chosen = mv.dump_chosen()
-        assert chosen == {
-            'current_choice': mv.current_choice,
-            'all_choices': mv.choices
-        }
+        assert chosen.chosen == mv.current_choice
+        assert chosen.meta['all_choices'] == mv.choices
 
-        chosen['current_choice'] = 5
         with pytest.raises(AssertionError):
-            mv.fix_chosen(chosen)
+            mv.fix_chosen(5)
 
-        chosen_copied = copy.deepcopy(chosen)
-        chosen_copied['all_choices'] = [1, 2, 3]
-        with pytest.raises(AssertionError):
-            mv.fix_chosen(chosen_copied)
+        # chosen_copied = copy.deepcopy(chosen)
+        # chosen_copied['all_choices'] = [1, 2, 3]
+        # with pytest.raises(AssertionError):
+        #     mv.fix_chosen(chosen_copied)
 
-        chosen['current_choice'] = 3
-        mv.fix_chosen(chosen)
+        mv.fix_chosen(3)
         assert mv.current_choice == 3
 
         with pytest.raises(RuntimeError):

--- a/tests/test_models/test_mutables/test_mutable_value.py
+++ b/tests/test_models/test_mutables/test_mutable_value.py
@@ -47,11 +47,6 @@ class TestMutableValue(TestCase):
         with pytest.raises(AssertionError):
             mv.fix_chosen(5)
 
-        # chosen_copied = copy.deepcopy(chosen)
-        # chosen_copied['all_choices'] = [1, 2, 3]
-        # with pytest.raises(AssertionError):
-        #     mv.fix_chosen(chosen_copied)
-
         mv.fix_chosen(3)
         assert mv.current_choice == 3
 

--- a/tests/test_models/test_mutables/test_onehotop.py
+++ b/tests/test_models/test_mutables/test_onehotop.py
@@ -44,9 +44,6 @@ class TestOneHotOP(TestCase):
         output = op.forward_arch_param(input, arch_param=arch_param)
         assert output is not None
 
-        output = op.forward_arch_param(input, arch_param=None)
-        assert output is not None
-
         # test when some element of arch_param is 0
         arch_param = nn.Parameter(torch.ones(op.num_choices))
         output = op.forward_arch_param(input, arch_param=arch_param)

--- a/tests/test_models/test_mutators/test_channel_mutator.py
+++ b/tests/test_models/test_mutators/test_channel_mutator.py
@@ -150,6 +150,18 @@ class TestChannelMutator(unittest.TestCase):
 
         # generate config
         model1 = copy.deepcopy(model)
-        mutator = ChannelMutator()
-        mutator.prepare_from_supernet(model1)
-        mutator.search_groups
+        mutator1 = ChannelMutator()
+        mutator1.prepare_from_supernet(model1)
+
+        self.assertEqual(len(mutator1.search_groups), 25)
+
+        custom_groups = [[
+            'backbone.layer2.1.conv.0.conv_(0, 240)_240',
+            'backbone.layer3.0.conv.0.conv_(0, 240)_240'
+        ]]
+
+        model2 = copy.deepcopy(model)
+        mutator2 = ChannelMutator(custom_groups=custom_groups)
+        mutator2.prepare_from_supernet(model2)
+
+        self.assertEqual(len(mutator2.search_groups), 24)

--- a/tests/test_models/test_mutators/test_channel_mutator.py
+++ b/tests/test_models/test_mutators/test_channel_mutator.py
@@ -134,3 +134,22 @@ class TestChannelMutator(unittest.TestCase):
                     parse_cfg={'type': 'Predefined'})
                 mutator.prepare_from_supernet(model)
                 self._test_a_mutator(mutator, model)
+
+    def test_custom_group(self):
+        ARCHITECTURE_CFG = dict(
+            type='mmcls.ImageClassifier',
+            backbone=dict(type='mmcls.MobileNetV2', widen_factor=1.5),
+            neck=dict(type='mmcls.GlobalAveragePooling'),
+            head=dict(
+                type='mmcls.LinearClsHead',
+                num_classes=1000,
+                in_channels=1920,
+                loss=dict(type='mmcls.CrossEntropyLoss', loss_weight=1.0),
+                topk=(1, 5)))
+        model = MODELS.build(ARCHITECTURE_CFG)
+
+        # generate config
+        model1 = copy.deepcopy(model)
+        mutator = ChannelMutator()
+        mutator.prepare_from_supernet(model1)
+        mutator.search_groups

--- a/tests/test_models/test_mutators/test_diff_mutator.py
+++ b/tests/test_models/test_mutators/test_diff_mutator.py
@@ -98,7 +98,8 @@ class TestDiffModuleMutator(TestCase):
             module_kwargs=dict(in_channels=32, out_channels=32, stride=1))
 
         self.MUTATOR_CFG = dict(
-            type='DiffModuleMutator', custom_group=[['op1'], ['op2'], ['op3']])
+            type='DiffModuleMutator',
+            custom_groups=[['op1'], ['op2'], ['op3']])
 
     def test_diff_mutator_diffop_layer(self) -> None:
         model = SearchableLayer(self.MUTABLE_CFG)
@@ -111,7 +112,7 @@ class TestDiffModuleMutator(TestCase):
         model = SearchableModel(self.MUTABLE_CFG)
 
         mutator_cfg = self.MUTATOR_CFG.copy()
-        mutator_cfg['custom_group'] = [
+        mutator_cfg['custom_groups'] = [
             ['slayer1.op1', 'slayer2.op1', 'slayer3.op1'],
             ['slayer1.op2', 'slayer2.op2', 'slayer3.op2'],
             ['slayer1.op3', 'slayer2.op3', 'slayer3.op3'],
@@ -128,7 +129,7 @@ class TestDiffModuleMutator(TestCase):
         model = SearchableModel(self.MUTABLE_CFG)
 
         mutator_cfg = self.MUTATOR_CFG.copy()
-        mutator_cfg['custom_group'] = [
+        mutator_cfg['custom_groups'] = [
             ['slayer1.op1', 'slayer2.op1', 'slayer3.op1'],
             ['slayer1.op2', 'slayer2.op2', 'slayer3.op2'],
             ['slayer1.op3', 'slayer2.op3', 'slayer3.op3_error_key'],
@@ -142,7 +143,7 @@ class TestDiffModuleMutator(TestCase):
         model = SearchableModelAlias(self.MUTABLE_CFG)
 
         mutator_cfg = self.MUTATOR_CFG.copy()
-        mutator_cfg['custom_group'] = [['op1'], ['op2'], ['op3']]
+        mutator_cfg['custom_groups'] = [['op1'], ['op2'], ['op3']]
         mutator: DiffModuleMutator = MODELS.build(mutator_cfg)
 
         mutator.prepare_from_supernet(model)
@@ -157,11 +158,11 @@ class TestDiffModuleMutator(TestCase):
         model = SearchableModelAlias(self.MUTABLE_CFG)
 
         mutator_cfg = self.MUTATOR_CFG.copy()
-        mutator_cfg['custom_group'] = [['op1'],
-                                       [
-                                           'slayer1.op2', 'slayer2.op2',
-                                           'slayer3.op2'
-                                       ], ['slayer1.op3', 'slayer2.op3']]
+        mutator_cfg['custom_groups'] = [['op1'],
+                                        [
+                                            'slayer1.op2', 'slayer2.op2',
+                                            'slayer3.op2'
+                                        ], ['slayer1.op3', 'slayer2.op3']]
         mutator: DiffModuleMutator = MODELS.build(mutator_cfg)
 
         mutator.prepare_from_supernet(model)
@@ -175,7 +176,7 @@ class TestDiffModuleMutator(TestCase):
         model = SearchableModel(self.MUTABLE_CFG)
 
         mutator_cfg = self.MUTATOR_CFG.copy()
-        mutator_cfg['custom_group'] = [
+        mutator_cfg['custom_groups'] = [
             ['slayer1.op1', 'slayer2.op1', 'slayer3.op1'],
             ['slayer1.op2', 'slayer2.op2', 'slayer3.op2'],
             ['slayer1.op3', 'slayer2.op3', 'slayer2.op3'],
@@ -189,7 +190,7 @@ class TestDiffModuleMutator(TestCase):
         model = SearchableModelAlias(self.MUTABLE_CFG)
 
         mutator_cfg = self.MUTATOR_CFG.copy()
-        mutator_cfg['custom_group'] = [
+        mutator_cfg['custom_groups'] = [
             ['op1', 'slayer1.op1', 'slayer2.op1', 'slayer3.op1'],
             ['slayer1.op2', 'slayer2.op2', 'slayer3.op2'],
             ['slayer1.op3', 'slayer2.op3', 'slayer3.op3'],
@@ -203,7 +204,7 @@ class TestDiffModuleMutator(TestCase):
         model = SearchableModel(self.MUTABLE_CFG)
 
         mutator_cfg = self.MUTATOR_CFG.copy()
-        mutator_cfg['custom_group'] = [
+        mutator_cfg['custom_groups'] = [
             ['illegal_key', 'slayer1.op1', 'slayer2.op1', 'slayer3.op1'],
             ['slayer1.op2', 'slayer2.op2', 'slayer3.op2'],
             ['slayer1.op3', 'slayer2.op3', 'slayer3.op3'],
@@ -217,7 +218,7 @@ class TestDiffModuleMutator(TestCase):
         model = SearchableModel(self.MUTABLE_CFG)
 
         mutator_cfg = self.MUTATOR_CFG.copy()
-        mutator_cfg['custom_group'] = [
+        mutator_cfg['custom_groups'] = [
             ['slayer1.op1', 'slayer2.op1', 'slayer3.op1'],
             ['slayer1.op2', 'slayer2.op2', 'slayer3.op2'],
             ['slayer1.op3', 'slayer2.op3', 'slayer3.op3'],

--- a/tests/test_models/test_subnet/test_fix_subnet.py
+++ b/tests/test_models/test_subnet/test_fix_subnet.py
@@ -57,8 +57,12 @@ class TestFixSubnet(TestCase):
 
         # fix subnet is dict
         fix_subnet = {
-            'mutable1': 'conv1',
-            'mutable2': 'conv2',
+            'mutable1': {
+                'chosen': 'conv1'
+            },
+            'mutable2': {
+                'chosen': 'conv2'
+            },
         }
 
         model = MockModel()
@@ -80,8 +84,12 @@ class TestFixSubnet(TestCase):
     def test_export_fix_subnet(self):
         # get FixSubnet
         fix_subnet = {
-            'mutable1': 'conv1',
-            'mutable2': 'conv2',
+            'mutable1': {
+                'chosen': 'conv1'
+            },
+            'mutable2': {
+                'chosen': 'conv2'
+            },
         }
 
         model = MockModel()
@@ -95,6 +103,14 @@ class TestFixSubnet(TestCase):
         model.mutable2.current_choice = 'conv2'
         exported_fix_subnet = export_fix_subnet(model)
 
+        mutable1_dump_chosen = exported_fix_subnet['mutable1']
+        mutable2_dump_chosen = exported_fix_subnet['mutable2']
+
+        mutable1_chosen_dict = dict(chosen=mutable1_dump_chosen.chosen)
+        mutable2_chosen_dict = dict(chosen=mutable2_dump_chosen.chosen)
+
+        exported_fix_subnet['mutable1'] = mutable1_chosen_dict
+        exported_fix_subnet['mutable2'] = mutable2_chosen_dict
         self.assertDictEqual(fix_subnet, exported_fix_subnet)
 
     def test_export_fix_subnet_with_derived_mutable(self) -> None:
@@ -102,7 +118,10 @@ class TestFixSubnet(TestCase):
         fix_subnet = export_fix_subnet(model)
         self.assertDictEqual(
             fix_subnet, {'source_mutable': model.source_mutable.dump_chosen()})
-        fix_subnet['source_mutable']['current_choice'] = 4
+
+        fix_subnet['source_mutable'] = dict(
+            fix_subnet['source_mutable']._asdict())
+        fix_subnet['source_mutable']['chosen'] = 4
         load_fix_subnet(model, fix_subnet)
         assert model.source_mutable.current_choice == 4
         assert model.derived_mutable.current_choice == 8
@@ -114,7 +133,10 @@ class TestFixSubnet(TestCase):
                 'source_mutable': model.source_mutable.dump_chosen(),
                 'derived_mutable': model.derived_mutable.dump_chosen()
             })
-        fix_subnet['source_mutable']['current_choice'] = 2
+
+        fix_subnet['source_mutable'] = dict(
+            fix_subnet['source_mutable']._asdict())
+        fix_subnet['source_mutable']['chosen'] = 2
         load_fix_subnet(model, fix_subnet)
         assert model.source_mutable.current_choice == 2
         assert model.derived_mutable.current_choice == 4


### PR DESCRIPTION
## Motivation

Refactor the mutable and mutator interface to make it more uniform

## Modification

1. Add `DumpChosen` and refactor `dump_chosen` api (return chosen and meta infos)
2. Clean up typehint
3. Extract the grouping logic in module mutator as ``GroupMixin``, which can be used in module, value and channel mutator

## BC-breaking (Optional)

1. `dump_chosen`
2. `load_fix_subnet`
3. All subnet YAML


