### PR TITLE
[Fix] Fix bug on mmrazor visualization, mismatch argument in define and use.

### DIFF
--- a/tools/visualizations/feature_diff_visualization.py
+++ b/tools/visualizations/feature_diff_visualization.py
@@ -20,7 +20,7 @@ def parse_args():
         'config1', help='train config file path for the first model')
     parser.add_argument(
         'config2', help='train config file path for the second model')
-    parser.add_argument('vis-config', help='visualization config file path')
+    parser.add_argument('vis_config', help='visualization config file path')
     parser.add_argument(
         'checkpoint1', help='Checkpoint file for the first model')
     parser.add_argument(

--- a/tools/visualizations/feature_visualization.py
+++ b/tools/visualizations/feature_visualization.py
@@ -17,7 +17,7 @@ def parse_args():
     parser = argparse.ArgumentParser(description='Feature map visualization')
     parser.add_argument('img', help='Image file')
     parser.add_argument('config', help='train config file path')
-    parser.add_argument('vis-config', help='visualization config file path')
+    parser.add_argument('vis_config', help='visualization config file path')
     parser.add_argument('checkpoint', help='Checkpoint file')
     parser.add_argument('--out-file', default=None, help='Path to output file')
     parser.add_argument(


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Hi, when i use the [MMRazor visualization](https://github.com/open-mmlab/mmrazor/blob/dev-1.x/docs/zh_cn/user_guides/visualization.md), i found the mismatch argument in define and use. Specifically, the define arg is `vis-config` but in use is `args.vis_config`, causing `AttributeError: 'Namespace' object has no attribute 'vis_config'` in my environment.

## Modification

change `vis-config` to `vis_config`

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

No

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
