### PR TITLE
[Refactor & Doc] Refactor graph_utils and add docstring and pytest

### DIFF
--- a/mmrazor/models/quantizers/base.py
+++ b/mmrazor/models/quantizers/base.py
@@ -4,6 +4,11 @@ from abc import abstractmethod
 import torch
 from mmengine.model import BaseModule
 
+from mmrazor.models.task_modules.tracer.fx import (
+    del_fakequant_after_function, del_fakequant_after_method,
+    del_fakequant_after_module, del_fakequant_after_op,
+    del_fakequant_before_function, del_fakequant_before_method,
+    del_fakequant_before_module, del_fakequant_before_op)
 from mmrazor.registry import TASK_UTILS
 
 
@@ -30,3 +35,54 @@ class BaseQuantizer(BaseModule):
         for name in modules_to_swap:
             del model._modules[name]
             model._modules[name] = torch.ao.nn.quantized.FXFloatFunctional()
+
+    def del_fakequant(self, prepared):
+        prepared = del_fakequant_before_module(
+            prepared, self.module_del_prev_fakequant, inplace=True)
+        prepared = del_fakequant_after_module(
+            prepared, self.module_del_next_fakequant, inplace=True)
+        prepared = del_fakequant_before_method(
+            prepared, self.method_del_prev_fakequant, inplace=True)
+        prepared = del_fakequant_after_method(
+            prepared, self.method_del_next_fakequant, inplace=True)
+        prepared = del_fakequant_before_function(
+            prepared, self.function_del_prev_fakequant, inplace=True)
+        prepared = del_fakequant_after_function(
+            prepared, self.function_del_next_fakequant, inplace=True)
+        prepared = del_fakequant_before_op(
+            prepared, self.op_del_prev_fakequant, inplace=True)
+        prepared = del_fakequant_after_op(
+            prepared, self.op_del_next_fakequant, inplace=True)
+        return prepared
+
+    @property
+    def module_del_prev_fakequant(self):
+        return tuple()
+
+    @property
+    def module_del_next_fakequant(self):
+        return tuple()
+
+    @property
+    def function_del_prev_fakequant(self):
+        return tuple()
+
+    @property
+    def function_del_next_fakequant(self):
+        return tuple()
+
+    @property
+    def method_del_prev_fakequant(self):
+        return tuple()
+
+    @property
+    def method_del_next_fakequant(self):
+        return tuple()
+
+    @property
+    def op_del_prev_fakequant(self):
+        return tuple()
+
+    @property
+    def op_del_next_fakequant(self):
+        return tuple()

--- a/mmrazor/models/quantizers/base.py
+++ b/mmrazor/models/quantizers/base.py
@@ -4,11 +4,6 @@ from abc import abstractmethod
 import torch
 from mmengine.model import BaseModule
 
-from mmrazor.models.task_modules.tracer.fx import (
-    del_fakequant_after_function, del_fakequant_after_method,
-    del_fakequant_after_module, del_fakequant_after_op,
-    del_fakequant_before_function, del_fakequant_before_method,
-    del_fakequant_before_module, del_fakequant_before_op)
 from mmrazor.registry import TASK_UTILS
 
 
@@ -19,7 +14,7 @@ class BaseQuantizer(BaseModule):
         self.tracer = TASK_UTILS.build(tracer)
 
     @abstractmethod
-    def prepare(self):
+    def prepare(self, model, graph_module):
         pass
 
     def swap_ff_with_fxff(self, model):
@@ -35,54 +30,3 @@ class BaseQuantizer(BaseModule):
         for name in modules_to_swap:
             del model._modules[name]
             model._modules[name] = torch.ao.nn.quantized.FXFloatFunctional()
-
-    def del_fakequant(self, prepared):
-        prepared = del_fakequant_before_module(
-            prepared, self.module_del_prev_fakequant, inplace=True)
-        prepared = del_fakequant_after_module(
-            prepared, self.module_del_next_fakequant, inplace=True)
-        prepared = del_fakequant_before_method(
-            prepared, self.method_del_prev_fakequant, inplace=True)
-        prepared = del_fakequant_after_method(
-            prepared, self.method_del_next_fakequant, inplace=True)
-        prepared = del_fakequant_before_function(
-            prepared, self.function_del_prev_fakequant, inplace=True)
-        prepared = del_fakequant_after_function(
-            prepared, self.function_del_next_fakequant, inplace=True)
-        prepared = del_fakequant_before_op(
-            prepared, self.op_del_prev_fakequant, inplace=True)
-        prepared = del_fakequant_after_op(
-            prepared, self.op_del_next_fakequant, inplace=True)
-        return prepared
-
-    @property
-    def module_del_prev_fakequant(self):
-        return tuple()
-
-    @property
-    def module_del_next_fakequant(self):
-        return tuple()
-
-    @property
-    def function_del_prev_fakequant(self):
-        return tuple()
-
-    @property
-    def function_del_next_fakequant(self):
-        return tuple()
-
-    @property
-    def method_del_prev_fakequant(self):
-        return tuple()
-
-    @property
-    def method_del_next_fakequant(self):
-        return tuple()
-
-    @property
-    def op_del_prev_fakequant(self):
-        return tuple()
-
-    @property
-    def op_del_next_fakequant(self):
-        return tuple()

--- a/mmrazor/models/quantizers/openvino_quantizer.py
+++ b/mmrazor/models/quantizers/openvino_quantizer.py
@@ -8,13 +8,6 @@ from mmrazor.models.task_modules.tracer.fx import build_graphmodule
 from mmrazor.registry import MODELS
 from .native_quantizer import NativeQuantizer
 
-MODULE_DEL_PREV_FAKEQUANT = (torch.nn.ReLU6, torch.nn.Identity)
-MODULE_DEL_NEXT_FAKEQUANT = (torch.nn.MaxPool2d, )
-TARGET_DEL_PREV_FAKEQUANT: Tuple = tuple()
-TARGET_DEL_NEXT_FAKEQUANT = ('flatten', )
-OP_DEL_PREV_FAKEQUANT = ('output', )
-OP_DEL_NEXT_FAKEQUANT: Tuple = tuple()
-
 
 @MODELS.register_module()
 class OpenVINOQuantizer(NativeQuantizer):

--- a/mmrazor/models/task_modules/tracer/fx/__init__.py
+++ b/mmrazor/models/task_modules/tracer/fx/__init__.py
@@ -1,14 +1,18 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 from .custom_tracer import (CustomTracer, UntracedMethodRegistry,
                             build_graphmodule, custom_symbolic_trace)
-from .graph_utils import (del_fakequant_after_module,
-                          del_fakequant_after_target,
-                          del_fakequant_before_module,
-                          del_fakequant_before_target)
+from .graph_utils import (del_fakequant_after_function,
+                          del_fakequant_after_method,
+                          del_fakequant_after_module, del_fakequant_after_op,
+                          del_fakequant_before_function,
+                          del_fakequant_before_method,
+                          del_fakequant_before_module, del_fakequant_before_op)
 
 __all__ = [
     'CustomTracer', 'UntracedMethodRegistry', 'custom_symbolic_trace',
     'build_graphmodule', 'del_fakequant_before_module',
-    'del_fakequant_after_module', 'del_fakequant_before_target',
-    'del_fakequant_after_target'
+    'del_fakequant_after_module', 'del_fakequant_after_function',
+    'del_fakequant_before_function', 'del_fakequant_after_op',
+    'del_fakequant_before_op', 'del_fakequant_before_method',
+    'del_fakequant_after_method'
 ]

--- a/mmrazor/models/task_modules/tracer/fx/graph_utils.py
+++ b/mmrazor/models/task_modules/tracer/fx/graph_utils.py
@@ -1,79 +1,132 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import copy
+from typing import Any, List, Tuple
 
+import torch.fx
 from torch.ao.quantization.fake_quantize import FakeQuantizeBase
 
 
-def _get_attrs(target, attrs):
+def _get_attrs(target: torch.nn.Module, attr: str) -> Any:
+    """Get the attribute from target.
 
-    attrs = attrs.split('.')
+    Args:
+        target (torch.nn.Module): Get the attribute from target module.
+        attr (str): The target attribute.
+
+    Returns:
+        Any: The target attribute.
+    """
+
+    attrs: List[str] = attr.split('.')
 
     for att in attrs:
         target = getattr(target, att, None)
     return target
 
 
-def del_fakequant_before_target(prepared_model, target_patterns, inplace=True):
+def recursive_find_erased_nodes(node, prepared_model):
+    """Find FakeQuant before target node recursively.
 
-    def recursive_find_erased_nodes(node):
-        """Find FakeQuant before target node recursively.
+    Examples:
+        head_fc = self.head.fc(activation_post_process_87);  \
+            activation_post_process_87 = None
+        activation_post_process_88 = \
+            self.activation_post_process_88(head_fc);  head_fc = None
+        head = self.head
+        _get_loss = head._get_loss(activation_post_process_88,
+            data_samples);  \
+            head = activation_post_process_88 = data_samples = None
+        return _get_loss
 
-        Examples:
-            head_fc = self.head.fc(activation_post_process_87);  \
-                activation_post_process_87 = None
-            activation_post_process_88 = \
-                self.activation_post_process_88(head_fc);  head_fc = None
-            head = self.head
-            _get_loss = head._get_loss(activation_post_process_88,
-                data_samples);  \
-                head = activation_post_process_88 = data_samples = None
-            return _get_loss
+    node                       |           node.args
+    --------------------
+    output                     | (_get_loss, )
+    _get_loss                  | (head, activation_post_process_88,
+                                    data_samples)
+    head                       | ()
+    activation_post_process_88 | (head_fc, )
+    data_samples               | (None, )
+    """
+    if node is None:
+        return []
 
-        node                       |           node.args
-        --------------------
-        output                     | (_get_loss, )
-        _get_loss                  | (head, activation_post_process_88,
-                                        data_samples)
-        head                       | ()
-        activation_post_process_88 | (head_fc, )
-        data_samples               | (None, )
-        """
-        if node is None:
-            return
-        if isinstance(
-                _get_attrs(prepared_model, node.target), FakeQuantizeBase):
-            nodes_to_erase.append(node)
-            return
-        for prev_node in node.args:
-            recursive_find_erased_nodes(prev_node)
-        for prev_node in node.kwargs.values():
-            recursive_find_erased_nodes(prev_node)
-        return
+    if node.op == 'call_module' and isinstance(
+            _get_attrs(prepared_model, node.target), FakeQuantizeBase):
+        return [node]
+
+    nodes_to_erase = []
+    for prev_node in node.args:
+        if isinstance(prev_node, torch.fx.Node):
+            nodes_to_erase.extend(
+                recursive_find_erased_nodes(prev_node, prepared_model))
+    for prev_node in node.kwargs.values():
+        if isinstance(prev_node, torch.fx.Node):
+            nodes_to_erase.extend(
+                recursive_find_erased_nodes(prev_node, prepared_model))
+
+    return nodes_to_erase
+
+
+def del_fakequant_before_op(prepared_model: torch.fx.GraphModule,
+                            target_ops: Tuple,
+                            inplace: bool = True) -> torch.fx.GraphModule:
+    """Delete useless fakequant before nodes whose ``op`` attribute (node.op)
+    is in `target_ops`.
+
+    Args:
+        prepared_model (GraphModule): Prepared standalone module.
+        target_ops (tuple): Fakequants before nodes whose op attribute
+            (node.op) is in `target_ops` will be deleted.
+        inplace (bool): Can optionally do the operation in-place. Defaults to
+            True.
+
+    Returns:
+        GraphModule: Prepared standalone module after deletion.
+    """
 
     if not inplace:
         prepared_model = copy.deepcopy(prepared_model)
     new_graph = copy.deepcopy(prepared_model.graph)
     for node in new_graph.nodes:
-        if node.target in target_patterns:
-            nodes_to_erase = []
-            recursive_find_erased_nodes(node)
+        if node.op in target_ops:
+            nodes_to_erase: List[torch.fx.Node] = recursive_find_erased_nodes(
+                node, prepared_model)
             for to_erase in nodes_to_erase:
+                assert to_erase.op == 'call_module' and isinstance(
+                    _get_attrs(prepared_model, to_erase.target),
+                    FakeQuantizeBase) and len(to_erase.args) == 1
                 to_erase.replace_all_uses_with(to_erase.args[0])
                 new_graph.erase_node(to_erase)
                 delattr(prepared_model, to_erase.target)
+
     new_graph.lint()
     prepared_model.graph = new_graph
     return prepared_model
 
 
-def del_fakequant_after_target(prepared_model, target_patterns, inplace=True):
+def del_fakequant_after_op(prepared_model: torch.fx.GraphModule,
+                           target_ops: Tuple,
+                           inplace: bool = True) -> torch.fx.GraphModule:
+    """Delete useless fakequant after nodes whose ``op`` attribute (node.op) is
+    in `target_ops`.
+
+    Args:
+        prepared_model (GraphModule): Prepared standalone module.
+        target_ops (tuple): Fakequants after nodes whose op attribute
+            (node.op) is in `target_ops` will be deleted.
+        inplace (bool): Can optionally do the operation in-place. Defaults to
+            True.
+
+    Returns:
+        GraphModule: Prepared standalone module after deletion.
+    """
     if not inplace:
         prepared_model = copy.deepcopy(prepared_model)
     new_graph = copy.deepcopy(prepared_model.graph)
 
     target_nodes = []
     for node in new_graph.nodes:
-        if node.target in target_patterns:
+        if node.op in target_ops:
             target_nodes.append(node)
 
     for node in new_graph.nodes:
@@ -86,12 +139,187 @@ def del_fakequant_after_target(prepared_model, target_patterns, inplace=True):
             node.replace_all_uses_with(prev_node)
             new_graph.erase_node(node)
             delattr(prepared_model, node.target)
+
     new_graph.lint()
     prepared_model.graph = new_graph
     return prepared_model
 
 
-def del_fakequant_before_module(prepared_model, module_patterns, inplace=True):
+def del_fakequant_before_method(prepared_model: torch.fx.GraphModule,
+                                method_patterns: Tuple,
+                                inplace: bool = True) -> torch.fx.GraphModule:
+    """Delete useless fakequant before nodes whose op attribute (node.op) is
+    `call_method` and target attribute (node.target) is in `target_patterns`.
+
+    Args:
+        prepared_model (GraphModule): Prepared standalone module.
+        target_patterns (tuple): Fakequants before nodes whose op attribute
+            (node.op) is `call_method` and target attribute (node.target) is
+            in `target_patterns` will be deleted.
+        inplace (bool): Can optionally do the operation in-place. Defaults to
+            True.
+
+    Returns:
+        GraphModule: Prepared standalone module after deletion.
+    """
+    if not inplace:
+        prepared_model = copy.deepcopy(prepared_model)
+    new_graph = copy.deepcopy(prepared_model.graph)
+    for node in new_graph.nodes:
+        if node.op == 'call_method' and node.target in method_patterns:
+            nodes_to_erase: List[torch.fx.Node] = recursive_find_erased_nodes(
+                node, prepared_model)
+            for to_erase in nodes_to_erase:
+                assert to_erase.op == 'call_module' and isinstance(
+                    _get_attrs(prepared_model, to_erase.target),
+                    FakeQuantizeBase) and len(to_erase.args) == 1
+                to_erase.replace_all_uses_with(to_erase.args[0])
+                new_graph.erase_node(to_erase)
+                delattr(prepared_model, to_erase.target)
+
+    new_graph.lint()
+    prepared_model.graph = new_graph
+    return prepared_model
+
+
+def del_fakequant_after_method(prepared_model: torch.fx.GraphModule,
+                               method_patterns: Tuple,
+                               inplace: bool = True) -> torch.fx.GraphModule:
+    """Delete useless fakequant after nodes whose op attribute (node.op) is
+    `call_method` and target attribute (node.target) is in `target_patterns`.
+
+    Args:
+        prepared_model (GraphModule): Prepared standalone module.
+        target_patterns (tuple): Fakequants after nodes whose op attribute
+            (node.op) is `call_method` and target attribute (node.target)
+            is in `target_patterns` will be deleted.
+        inplace (bool): Can optionally do the operation in-place. Defaults to
+            True.
+
+    Returns:
+        GraphModule: Prepared standalone module after deletion.
+    """
+    if not inplace:
+        prepared_model = copy.deepcopy(prepared_model)
+    new_graph = copy.deepcopy(prepared_model.graph)
+
+    target_nodes = []
+    for node in new_graph.nodes:
+        if node.op == 'call_method' and node.target in method_patterns:
+            target_nodes.append(node)
+
+    for node in new_graph.nodes:
+        if node.op == 'call_module' and isinstance(
+                _get_attrs(prepared_model, node.target), FakeQuantizeBase):
+            assert len(node.args) == 1
+            prev_node = node.args[0]
+            if prev_node not in target_nodes:
+                continue
+            node.replace_all_uses_with(prev_node)
+            new_graph.erase_node(node)
+            delattr(prepared_model, node.target)
+
+    new_graph.lint()
+    prepared_model.graph = new_graph
+    return prepared_model
+
+
+def del_fakequant_before_function(
+        prepared_model: torch.fx.GraphModule,
+        function_patterns: Tuple,
+        inplace: bool = True) -> torch.fx.GraphModule:
+    """Delete useless fakequant before nodes whose op attribute (node.op) is
+    `call_function` and target attribute (node.target) is in `target_patterns`.
+
+    Args:
+        prepared_model (GraphModule): Prepared standalone module.
+        target_patterns (tuple): Fakequants before nodes whose op attribute
+            (node.op) is `call_function` and target attribute (node.target) is
+            in `target_patterns` will be deleted.
+        inplace (bool): Can optionally do the operation in-place. Defaults to
+            True.
+
+    Returns:
+        GraphModule: Prepared standalone module after deletion.
+    """
+    if not inplace:
+        prepared_model = copy.deepcopy(prepared_model)
+    new_graph = copy.deepcopy(prepared_model.graph)
+    for node in new_graph.nodes:
+        if node.op == 'call_function' and node.target in function_patterns:
+            nodes_to_erase: List[torch.fx.Node] = recursive_find_erased_nodes(
+                node, prepared_model)
+            for to_erase in nodes_to_erase:
+                assert to_erase.op == 'call_module' and isinstance(
+                    _get_attrs(prepared_model, to_erase.target),
+                    FakeQuantizeBase) and len(to_erase.args) == 1
+                to_erase.replace_all_uses_with(to_erase.args[0])
+                new_graph.erase_node(to_erase)
+                delattr(prepared_model, to_erase.target)
+
+    new_graph.lint()
+    prepared_model.graph = new_graph
+    return prepared_model
+
+
+def del_fakequant_after_function(prepared_model: torch.fx.GraphModule,
+                                 function_patterns: Tuple,
+                                 inplace: bool = True) -> torch.fx.GraphModule:
+    """Delete useless fakequant after nodes whose op attribute (node.op) is
+    `call_function` and target attribute (node.target) is in `target_patterns`.
+
+    Args:
+        prepared_model (GraphModule): Prepared standalone module.
+        function_patterns (tuple): Fakequants after nodes whose op attribute
+            (node.op) is `call_function` and target attribute (node.target) is
+            in `target_patterns` will be deleted.
+        inplace (bool): Can optionally do the operation in-place. Defaults to
+            True.
+
+    Returns:
+        GraphModule: Prepared standalone module after deletion.
+    """
+    if not inplace:
+        prepared_model = copy.deepcopy(prepared_model)
+    new_graph = copy.deepcopy(prepared_model.graph)
+
+    target_nodes = []
+    for node in new_graph.nodes:
+        if node.op == 'call_function' and node.target in function_patterns:
+            target_nodes.append(node)
+
+    for node in new_graph.nodes:
+        if node.op == 'call_module' and isinstance(
+                _get_attrs(prepared_model, node.target), FakeQuantizeBase):
+            assert len(node.args) == 1
+            prev_node = node.args[0]
+            if prev_node not in target_nodes:
+                continue
+            node.replace_all_uses_with(prev_node)
+            new_graph.erase_node(node)
+            delattr(prepared_model, node.target)
+
+    new_graph.lint()
+    prepared_model.graph = new_graph
+    return prepared_model
+
+
+def del_fakequant_before_module(prepared_model: torch.fx.GraphModule,
+                                module_patterns: Tuple,
+                                inplace: bool = True) -> torch.fx.GraphModule:
+    """Delete useless fakequant before modules whose type are in
+    `module_patterns`.
+
+    Args:
+        prepared_model (GraphModule): Prepared standalone module.
+        target_patterns (tuple): Fakequants before modules whose type is in
+            `module_patterns` will be deleted.
+        inplace (bool): Can optionally do the operation in-place.
+            Defaults to True.
+
+    Returns:
+        GraphModule: Prepared standalone module after deletion.
+    """
     if not inplace:
         prepared_model = copy.deepcopy(prepared_model)
     new_graph = copy.deepcopy(prepared_model.graph)
@@ -99,21 +327,35 @@ def del_fakequant_before_module(prepared_model, module_patterns, inplace=True):
         if node.op == 'call_module' and isinstance(
                 _get_attrs(prepared_model, node.target), module_patterns):
             to_erase = node.args[0]
-            if not isinstance(
+            if not (to_erase.op == 'call_module' and isinstance(
                     _get_attrs(prepared_model, to_erase.target),
-                    FakeQuantizeBase):
-                continue
-            if len(to_erase.users) > 1:
+                    FakeQuantizeBase)):
                 continue
             to_erase.replace_all_uses_with(to_erase.args[0])
             new_graph.erase_node(to_erase)
             delattr(prepared_model, to_erase.target)
+
     new_graph.lint()
     prepared_model.graph = new_graph
     return prepared_model
 
 
-def del_fakequant_after_module(prepared_model, module_patterns, inplace=True):
+def del_fakequant_after_module(prepared_model: torch.fx.GraphModule,
+                               module_patterns: Tuple,
+                               inplace: bool = True) -> torch.fx.GraphModule:
+    """Delete useless fakequant after modules whose type are in
+    `module_patterns`.
+
+    Args:
+        prepared_model (GraphModule): Prepared standalone module.
+        target_patterns (tuple): Fakequants after modules whose type is in
+            `module_patterns` will be deleted.
+        inplace (bool): Can optionally do the operation in-place.
+            Defaults to True.
+
+    Returns:
+        GraphModule: Prepared standalone module after deletion.
+    """
     if not inplace:
         prepared_model = copy.deepcopy(prepared_model)
     new_graph = copy.deepcopy(prepared_model.graph)
@@ -133,6 +375,7 @@ def del_fakequant_after_module(prepared_model, module_patterns, inplace=True):
             node.replace_all_uses_with(prev_node)
             new_graph.erase_node(node)
             delattr(prepared_model, node.target)
+
     new_graph.lint()
     prepared_model.graph = new_graph
     return prepared_model

--- a/tests/test_models/test_task_modules/test_graph_utils.py
+++ b/tests/test_models/test_task_modules/test_graph_utils.py
@@ -1,0 +1,499 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import operator
+from unittest import TestCase
+
+import torch
+import torch.nn as nn
+from torch.ao.quantization import QConfigMapping
+from torch.ao.quantization.fake_quantize import FakeQuantizeBase
+from torch.ao.quantization.fx import prepare
+from torch.ao.quantization.quantize_fx import _fuse_fx
+
+from mmrazor.models.task_modules import build_graphmodule
+from mmrazor.models.task_modules.tracer import CustomTracer
+from mmrazor.models.task_modules.tracer.fx import (
+    del_fakequant_after_function, del_fakequant_after_method,
+    del_fakequant_after_module, del_fakequant_after_op,
+    del_fakequant_before_function, del_fakequant_before_method,
+    del_fakequant_before_module, del_fakequant_before_op)
+from mmrazor.structures.quantization import BackendConfigs, QConfigHander
+
+
+def _get_attrs(target, attrs):
+    attrs = attrs.split('.')
+
+    for att in attrs:
+        target = getattr(target, att, None)
+    return target
+
+
+class BasicBlock(nn.Module):
+
+    def __init__(self, in_channels, out_channels):
+        super(BasicBlock, self).__init__()
+        self.in_channels = in_channels
+        self.out_channels = out_channels
+        self.mid_channels = out_channels
+
+        self.norm1 = nn.BatchNorm2d(self.mid_channels)
+        self.norm2 = nn.BatchNorm2d(out_channels)
+        self.conv1 = nn.Conv2d(in_channels, self.mid_channels, 1)
+        self.conv2 = nn.Conv2d(self.mid_channels, out_channels, 1)
+
+        self.relu = nn.ReLU6()
+        self.drop_path = nn.Identity()
+
+    def forward(self, x):
+
+        def _inner_forward(x):
+            identity = x
+
+            out = self.conv1(x)
+            out = self.norm1(out)
+            out = self.relu(out)
+
+            out = self.conv2(out)
+            out = self.norm2(out)
+
+            out = self.drop_path(out)
+
+            out += identity
+
+            return out
+
+        out = _inner_forward(x)
+
+        out = self.relu(out)
+
+        return out
+
+
+class ToyModel(nn.Module):
+
+    def __init__(self):
+        super().__init__()
+        self.stem_layer = nn.Sequential(
+            nn.Conv2d(3, 3, 1), nn.BatchNorm2d(3), nn.ReLU())
+        self.maxpool = nn.MaxPool2d(kernel_size=3, stride=2, padding=1)
+        self.block = BasicBlock(3, 3)
+        self.block2 = BasicBlock(3, 3)
+        self.gap = nn.AdaptiveAvgPool2d((1, 1))
+        self.fc = nn.Linear(3, 4)
+
+    def forward(self, x):
+        x = self.stem_layer(x)
+        x = self.maxpool(x)
+        x = self.block(x)
+        x = self.block2(x)
+        x = self.gap(x)
+        x = x.flatten(1)
+        x = self.fc(x)
+        return x
+
+
+global_qconfig = dict(
+    w_observer=dict(type='mmrazor.PerChannelMinMaxObserver'),
+    a_observer=dict(type='mmrazor.MovingAverageMinMaxObserver'),
+    w_fake_quant=dict(type='mmrazor.FakeQuantize'),
+    a_fake_quant=dict(type='mmrazor.FakeQuantize'),
+    w_qscheme=dict(
+        qdtype='qint8', bit=8, is_symmetry=True, is_symmetric_range=True),
+    a_qscheme=dict(
+        qdtype='quint8', bit=8, is_symmetry=True, averaging_constant=0.1),
+)
+
+
+class TestGraphUtils(TestCase):
+
+    def setUp(self):
+        self.tracer = CustomTracer()
+        self.backend_config = BackendConfigs['native']
+        self.qconfig = QConfigHander(global_qconfig)
+        self.qconfig_mapping = QConfigMapping().set_global(
+            self.qconfig.convert())
+        self.example_inputs = (torch.randn(1, 3, 224, 224), )
+
+    def swap_ff_with_fxff(self, model):
+        modules_to_swap = []
+        for name, module in model.named_children():
+            if isinstance(module, torch.ao.nn.quantized.FloatFunctional):
+                modules_to_swap.append(name)
+            else:
+                self.swap_ff_with_fxff(module)
+
+        for name in modules_to_swap:
+            del model._modules[name]
+            model._modules[name] = torch.ao.nn.quantized.FXFloatFunctional()
+
+    def test_del_fakequant_before_op(self):
+        model_to_quantize = ToyModel()
+        model_to_quantize.eval()
+
+        self.swap_ff_with_fxff(model_to_quantize)
+        traced_graph = self.tracer.trace(model_to_quantize)
+        graph_module = build_graphmodule(model_to_quantize, traced_graph)
+
+        graph_module = _fuse_fx(
+            graph_module=graph_module,
+            is_qat=True,
+            backend_config=self.backend_config)
+        prepared = prepare(
+            model=graph_module,
+            qconfig_mapping=self.qconfig_mapping,
+            is_qat=True,
+            node_name_to_scope=self.tracer.node_name_to_scope,
+            example_inputs=self.example_inputs,
+            backend_config=self.backend_config)
+
+        op_del_prev_fakequant = ('output', )
+
+        prepared_after_del = del_fakequant_before_op(
+            prepared, op_del_prev_fakequant, inplace=False)
+        for node in prepared.graph.nodes:
+            if node.op in op_del_prev_fakequant:
+                args = node.args
+                self.assertIsInstance(
+                    _get_attrs(prepared, args[0].target), FakeQuantizeBase)
+
+        for node in prepared_after_del.graph.nodes:
+            if node.op in op_del_prev_fakequant:
+                args = node.args
+                self.assertNotIsInstance(
+                    _get_attrs(prepared, args[0].target), FakeQuantizeBase)
+
+        prepared_after_del = del_fakequant_before_op(
+            prepared, op_del_prev_fakequant, inplace=True)
+        for node in prepared_after_del.graph.nodes:
+            if node.op in op_del_prev_fakequant:
+                args = node.args
+                self.assertNotIsInstance(
+                    _get_attrs(prepared, args[0].target), FakeQuantizeBase)
+
+    def test_del_fakequant_after_op(self):
+        model_to_quantize = ToyModel()
+        model_to_quantize.eval()
+
+        self.swap_ff_with_fxff(model_to_quantize)
+        traced_graph = self.tracer.trace(model_to_quantize)
+        graph_module = build_graphmodule(model_to_quantize, traced_graph)
+
+        graph_module = _fuse_fx(
+            graph_module=graph_module,
+            is_qat=True,
+            backend_config=self.backend_config)
+        prepared = prepare(
+            model=graph_module,
+            qconfig_mapping=self.qconfig_mapping,
+            is_qat=True,
+            node_name_to_scope=self.tracer.node_name_to_scope,
+            example_inputs=self.example_inputs,
+            backend_config=self.backend_config)
+
+        op_del_next_fakequant = ('placeholder', )
+
+        prepared_after_del = del_fakequant_after_op(
+            prepared, op_del_next_fakequant, inplace=False)
+        for node in prepared.graph.nodes:
+            if node.op in op_del_next_fakequant:
+                self.assertIsInstance(
+                    _get_attrs(prepared, node.next.target), FakeQuantizeBase)
+
+        for node in prepared_after_del.graph.nodes:
+            if node.op in op_del_next_fakequant:
+                self.assertNotIsInstance(
+                    _get_attrs(prepared, node.next.target), FakeQuantizeBase)
+
+        prepared_after_del = del_fakequant_after_op(
+            prepared, op_del_next_fakequant, inplace=True)
+        for node in prepared_after_del.graph.nodes:
+            if node.op in op_del_next_fakequant:
+                self.assertNotIsInstance(
+                    _get_attrs(prepared, node.next.target), FakeQuantizeBase)
+
+    def test_del_fakequant_before_method(self):
+
+        model_to_quantize = ToyModel()
+        model_to_quantize.eval()
+
+        self.swap_ff_with_fxff(model_to_quantize)
+        traced_graph = self.tracer.trace(model_to_quantize)
+        graph_module = build_graphmodule(model_to_quantize, traced_graph)
+
+        graph_module = _fuse_fx(
+            graph_module=graph_module,
+            is_qat=True,
+            backend_config=self.backend_config)
+        prepared = prepare(
+            model=graph_module,
+            qconfig_mapping=self.qconfig_mapping,
+            is_qat=True,
+            node_name_to_scope=self.tracer.node_name_to_scope,
+            example_inputs=self.example_inputs,
+            backend_config=self.backend_config)
+
+        method_del_prev_fakequant = ('flatten', )
+
+        prepared_after_del = del_fakequant_before_method(
+            prepared, method_del_prev_fakequant, inplace=False)
+        for node in prepared.graph.nodes:
+            if node.op == 'call_method' and \
+                    node.target in method_del_prev_fakequant:
+                args = node.args
+                self.assertIsInstance(
+                    _get_attrs(prepared, args[0].target), FakeQuantizeBase)
+
+        for node in prepared_after_del.graph.nodes:
+            if node.op == 'call_method' and \
+                    node.target in method_del_prev_fakequant:
+                args = node.args
+                self.assertNotIsInstance(
+                    _get_attrs(prepared, args[0].target), FakeQuantizeBase)
+
+        prepared_after_del = del_fakequant_before_method(
+            prepared, method_del_prev_fakequant, inplace=True)
+        for node in prepared_after_del.graph.nodes:
+            if node.op == 'call_method' and \
+                    node.target in method_del_prev_fakequant:
+                args = node.args
+                self.assertNotIsInstance(
+                    _get_attrs(prepared, args[0].target), FakeQuantizeBase)
+
+    def test_del_fakequant_after_method(self):
+        model_to_quantize = ToyModel()
+        model_to_quantize.eval()
+
+        self.swap_ff_with_fxff(model_to_quantize)
+        traced_graph = self.tracer.trace(model_to_quantize)
+        graph_module = build_graphmodule(model_to_quantize, traced_graph)
+
+        graph_module = _fuse_fx(
+            graph_module=graph_module,
+            is_qat=True,
+            backend_config=self.backend_config)
+        prepared = prepare(
+            model=graph_module,
+            qconfig_mapping=self.qconfig_mapping,
+            is_qat=True,
+            node_name_to_scope=self.tracer.node_name_to_scope,
+            example_inputs=self.example_inputs,
+            backend_config=self.backend_config)
+
+        method_del_next_fakequant = ('flatten', )
+
+        prepared_after_del = del_fakequant_after_method(
+            prepared, method_del_next_fakequant, inplace=False)
+        for node in prepared.graph.nodes:
+            if node.op == 'call_method' and \
+                    node.target in method_del_next_fakequant:
+                self.assertIsInstance(
+                    _get_attrs(prepared, node.next.target), FakeQuantizeBase)
+
+        for node in prepared_after_del.graph.nodes:
+            if node.op == 'call_method' and \
+                    node.target in method_del_next_fakequant:
+                self.assertNotIsInstance(
+                    _get_attrs(prepared, node.next.target), FakeQuantizeBase)
+
+        prepared_after_del = del_fakequant_after_method(
+            prepared, method_del_next_fakequant, inplace=True)
+        for node in prepared_after_del.graph.nodes:
+            if node.op == 'call_method' and \
+                    node.target in method_del_next_fakequant:
+                self.assertNotIsInstance(
+                    _get_attrs(prepared, node.next.target), FakeQuantizeBase)
+
+    def test_del_fakequant_before_function(self):
+        model_to_quantize = ToyModel()
+        model_to_quantize.eval()
+
+        self.swap_ff_with_fxff(model_to_quantize)
+        traced_graph = self.tracer.trace(model_to_quantize)
+        graph_module = build_graphmodule(model_to_quantize, traced_graph)
+
+        graph_module = _fuse_fx(
+            graph_module=graph_module,
+            is_qat=True,
+            backend_config=self.backend_config)
+        prepared = prepare(
+            model=graph_module,
+            qconfig_mapping=self.qconfig_mapping,
+            is_qat=True,
+            node_name_to_scope=self.tracer.node_name_to_scope,
+            example_inputs=self.example_inputs,
+            backend_config=self.backend_config)
+
+        function_del_prev_fakequant = (operator.add, )
+
+        prepared_after_del = del_fakequant_before_function(
+            prepared, function_del_prev_fakequant, inplace=False)
+        for node in prepared.graph.nodes:
+            if node.op == 'call_function' and \
+                    node.target in function_del_prev_fakequant:
+                args = node.args
+                self.assertIsInstance(
+                    _get_attrs(prepared, args[0].target), FakeQuantizeBase)
+
+        for node in prepared_after_del.graph.nodes:
+            if node.op == 'call_function' and \
+                    node.target in function_del_prev_fakequant:
+                args = node.args
+                self.assertEqual(len(args), 2)
+                self.assertNotIsInstance(
+                    _get_attrs(prepared, args[0].target), FakeQuantizeBase)
+                self.assertNotIsInstance(
+                    _get_attrs(prepared, args[1].target), FakeQuantizeBase)
+
+        prepared_after_del = del_fakequant_before_function(
+            prepared, function_del_prev_fakequant, inplace=True)
+        for node in prepared_after_del.graph.nodes:
+            if node.op == 'call_function' and \
+                    node.target in function_del_prev_fakequant:
+                args = node.args
+                self.assertEqual(len(args), 2)
+                self.assertNotIsInstance(
+                    _get_attrs(prepared, args[0].target), FakeQuantizeBase)
+                self.assertNotIsInstance(
+                    _get_attrs(prepared, args[1].target), FakeQuantizeBase)
+
+    def test_del_fakequant_after_function(self):
+        model_to_quantize = ToyModel()
+        model_to_quantize.eval()
+
+        self.swap_ff_with_fxff(model_to_quantize)
+        traced_graph = self.tracer.trace(model_to_quantize)
+        graph_module = build_graphmodule(model_to_quantize, traced_graph)
+
+        graph_module = _fuse_fx(
+            graph_module=graph_module,
+            is_qat=True,
+            backend_config=self.backend_config)
+        prepared = prepare(
+            model=graph_module,
+            qconfig_mapping=self.qconfig_mapping,
+            is_qat=True,
+            node_name_to_scope=self.tracer.node_name_to_scope,
+            example_inputs=self.example_inputs,
+            backend_config=self.backend_config)
+
+        function_del_next_fakequant = (operator.add, )
+
+        prepared_after_del = del_fakequant_after_function(
+            prepared, function_del_next_fakequant, inplace=False)
+        for node in prepared.graph.nodes:
+            if node.op == 'call_function' and \
+                    node.target in function_del_next_fakequant:
+                self.assertIsInstance(
+                    _get_attrs(prepared, node.next.target), FakeQuantizeBase)
+
+        for node in prepared_after_del.graph.nodes:
+            if node.op == 'call_function' and \
+                    node.target in function_del_next_fakequant:
+                self.assertNotIsInstance(
+                    _get_attrs(prepared, node.next.target), FakeQuantizeBase)
+
+        prepared_after_del = del_fakequant_after_function(
+            prepared, function_del_next_fakequant, inplace=True)
+        for node in prepared_after_del.graph.nodes:
+            if node.op == 'call_function' and \
+                    node.target in function_del_next_fakequant:
+                self.assertNotIsInstance(
+                    _get_attrs(prepared, node.next.target), FakeQuantizeBase)
+
+    def test_del_fakequant_before_module(self):
+        model_to_quantize = ToyModel()
+        model_to_quantize.eval()
+
+        self.swap_ff_with_fxff(model_to_quantize)
+        traced_graph = self.tracer.trace(model_to_quantize)
+        graph_module = build_graphmodule(model_to_quantize, traced_graph)
+
+        graph_module = _fuse_fx(
+            graph_module=graph_module,
+            is_qat=True,
+            backend_config=self.backend_config)
+        prepared = prepare(
+            model=graph_module,
+            qconfig_mapping=self.qconfig_mapping,
+            is_qat=True,
+            node_name_to_scope=self.tracer.node_name_to_scope,
+            example_inputs=self.example_inputs,
+            backend_config=self.backend_config)
+
+        module_del_prev_fakequant = (torch.nn.ReLU6, torch.nn.Identity)
+
+        prepared_after_del = del_fakequant_before_module(
+            prepared, module_del_prev_fakequant, inplace=False)
+        for node in prepared.graph.nodes:
+            if node.op == 'call_module' and isinstance(
+                    _get_attrs(prepared, node.target),
+                    module_del_prev_fakequant):
+                args = node.args
+                self.assertIsInstance(
+                    _get_attrs(prepared, args[0].target), FakeQuantizeBase)
+
+        for node in prepared_after_del.graph.nodes:
+            if node.op == 'call_module' and isinstance(
+                    _get_attrs(prepared, node.target),
+                    module_del_prev_fakequant):
+                args = node.args
+                if args[0].op == 'call_module':
+                    self.assertNotIsInstance(
+                        _get_attrs(prepared, args[0].target), FakeQuantizeBase)
+
+        prepared_after_del = del_fakequant_before_module(
+            prepared, module_del_prev_fakequant, inplace=True)
+        for node in prepared_after_del.graph.nodes:
+            if node.op == 'call_module' and isinstance(
+                    _get_attrs(prepared, node.target),
+                    module_del_prev_fakequant):
+                args = node.args
+                if args[0].op == 'call_module':
+                    self.assertNotIsInstance(
+                        _get_attrs(prepared, args[0].target), FakeQuantizeBase)
+
+    def test_del_fakequant_after_module(self):
+        model_to_quantize = ToyModel()
+        model_to_quantize.eval()
+
+        self.swap_ff_with_fxff(model_to_quantize)
+        traced_graph = self.tracer.trace(model_to_quantize)
+        graph_module = build_graphmodule(model_to_quantize, traced_graph)
+
+        graph_module = _fuse_fx(
+            graph_module=graph_module,
+            is_qat=True,
+            backend_config=self.backend_config)
+        prepared = prepare(
+            model=graph_module,
+            qconfig_mapping=self.qconfig_mapping,
+            is_qat=True,
+            node_name_to_scope=self.tracer.node_name_to_scope,
+            example_inputs=self.example_inputs,
+            backend_config=self.backend_config)
+
+        module_del_next_fakequant = (torch.nn.MaxPool2d, )
+
+        prepared_after_del = del_fakequant_after_module(
+            prepared, module_del_next_fakequant, inplace=False)
+        for node in prepared.graph.nodes:
+            if node.op == 'call_module' and isinstance(
+                    _get_attrs(prepared, node.target),
+                    module_del_next_fakequant):
+                self.assertIsInstance(
+                    _get_attrs(prepared, node.next.target), FakeQuantizeBase)
+
+        for node in prepared_after_del.graph.nodes:
+            if node.op == 'call_module' and isinstance(
+                    _get_attrs(prepared, node.target),
+                    module_del_next_fakequant):
+                self.assertNotIsInstance(
+                    _get_attrs(prepared, node.next.target), FakeQuantizeBase)
+
+        prepared_after_del = del_fakequant_after_module(
+            prepared, module_del_next_fakequant, inplace=True)
+        for node in prepared_after_del.graph.nodes:
+            if node.op == 'call_module' and isinstance(
+                    _get_attrs(prepared, node.target),
+                    module_del_next_fakequant):
+                self.assertNotIsInstance(
+                    _get_attrs(prepared, node.next.target), FakeQuantizeBase)


### PR DESCRIPTION
## Modification

1. Refactor graph_utils: We support deleting fakequant before / after  op / method / function / module in graph_utils.
2. Add 8 properties to `BaseQuantizer`. Each is a tuple. For example, the `module_del_prev_fakequant` property in `OpenVINOQuantizer` is (torch.nn.ReLU6, torch.nn.Identity). These properties are determined by the backend, so maybe they need to be regarded as properties.
3. Add the corresponding pytest and docstring.
