### PR TITLE
call after_val_epoch hooks only once to save best ckpt correctly

### DIFF
--- a/mmrazor/engine/runner/distill_val_loop.py
+++ b/mmrazor/engine/runner/distill_val_loop.py
@@ -52,30 +52,17 @@ class SingleTeacherDistillValLoop(ValLoop):
             self.run_iter(idx, data_batch)
         # compute student metrics
         metrics = self.evaluator.evaluate(len(self.dataloader.dataset))
-        student_metrics = dict()
-        for key, value in metrics.items():
-            student_key = 'student.' + key
-            teacher_key = 'teacher.' + key
-
-            student_metrics[student_key] = value
-            self.runner.message_hub.log_scalars.pop(f'val/{teacher_key}', None)
-
-        self.runner.call_hook('after_val_epoch', metrics=student_metrics)
 
         self.runner.call_hook('before_val_epoch')
         for idx, data_batch in enumerate(self.dataloader):
             self.run_iter_teacher(idx, data_batch)
         # compute teacher metrics
-        metrics = self.evaluator.evaluate(len(self.dataloader.dataset))
-        teacher_metrics = dict()
-        for key, value in metrics.items():
-            student_key = 'student.' + key
+        teacher_metrics = self.evaluator.evaluate(len(self.dataloader.dataset))
+        for key, value in teacher_metrics.items():
             teacher_key = 'teacher.' + key
+            metrics[teacher_key] = value
 
-            teacher_metrics[teacher_key] = value
-            self.runner.message_hub.log_scalars.pop(f'val/{student_key}', None)
-
-        self.runner.call_hook('after_val_epoch', metrics=teacher_metrics)
+        self.runner.call_hook('after_val_epoch', metrics=metrics)
         self.runner.call_hook('after_val')
 
     @torch.no_grad()


### PR DESCRIPTION
## Motivation

`SingleTeacherDistillValLoop` calls `after_val_epoch` hooks twice during the evaluation. However, the metric in the second call do not contain the key named `student.accuracy/top1`. As a result, if we set `save_best='auto'` in `CheckpointHook`, the program will fail.

Please refer to this [issue](https://github.com/open-mmlab/mmrazor/issues/396#issuecomment-1369535233) for more details.


## Modification

Now we only call `after_val_epoch` hooks once in `SingleTeacherDistillValLoop`.
