### PR TITLE
[Fix] fix the bug in Recorders when nn.Module contains the 'inplace' …

### DIFF
--- a/mmrazor/models/algorithms/distill/configurable/single_teacher_distill.py
+++ b/mmrazor/models/algorithms/distill/configurable/single_teacher_distill.py
@@ -32,6 +32,8 @@ class SingleTeacherDistill(BaseAlgorithm):
             to True.
         calculate_student_loss (bool): Whether to calculate student loss
             (original task loss) to update student model. Defaults to True.
+        teacher_module_inplace(bool): Whether to allow teacher module inplace
+            attribute True. Defaults to False.
     """
 
     def __init__(self,
@@ -42,6 +44,7 @@ class SingleTeacherDistill(BaseAlgorithm):
                  teacher_norm_eval: bool = True,
                  student_trainable: bool = True,
                  calculate_student_loss: bool = True,
+                 teacher_module_inplace: bool = False,
                  **kwargs) -> None:
         super().__init__(**kwargs)
 
@@ -56,6 +59,13 @@ class SingleTeacherDistill(BaseAlgorithm):
                             f'{type(teacher)}')
 
         self.teacher = teacher
+
+        # Find all nn.Modules in the model that contain the 'inplace' attribute
+        # and set them to False.
+        self.teacher_module_inplace = teacher_module_inplace
+        if not self.teacher_module_inplace:
+            self.set_module_inplace_false(teacher, 'self.teacher')
+
         if teacher_ckpt:
             # avoid loaded parameters be overwritten
             self.teacher.init_weights()


### PR DESCRIPTION
…attribute


## Motivation

Find all nn.Modules in the model that contain the 'inplace'  attribute and set them to False in order to prevent occur error in Recorders using recursion algorithm.

## Modification

Write a new function, it will disassemble the Args architecture .If type 'nn.Module' is detected, determine if it contains an 'inplace' attribute and set False if it does. If none, get the OrderedDict and then iterate through the dictionary to continue the recursive search.
And call this function in class BaseAlgorithm init and class SingleTeacherDistill init function.
Because my academic level is limited and this is my first pulling request, the implementation method and quality may be poor. I sincerely hope that I can get some suggestions from you.


## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
