### PR TITLE
[Improvement] Init teacher weight by default

### DIFF
--- a/mmrazor/models/algorithms/distill/configurable/single_teacher_distill.py
+++ b/mmrazor/models/algorithms/distill/configurable/single_teacher_distill.py
@@ -56,9 +56,9 @@ class SingleTeacherDistill(BaseAlgorithm):
                             f'{type(teacher)}')
 
         self.teacher = teacher
+        self.teacher.init_weights()
         if teacher_ckpt:
             # avoid loaded parameters be overwritten
-            self.teacher.init_weights()
             _ = load_checkpoint(self.teacher, teacher_ckpt)
         self.teacher_trainable = teacher_trainable
         if not self.teacher_trainable:


### PR DESCRIPTION
Init teacher weight by default


## Motivation

Before this PR, we can only load the weight of teacher if we provide `teacher_ckpt`. And we can't specify the `map_location` to cpu if we use `teacher_ckpt`, this would cost huge gpu memory in the first gpu.

By the way, i did not find any reason to provide teacher_ckpt if we have provided the `init_cfg` to the teacher, can we force users to use only init_cfg?

## Modification

init teacher weight by default

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
