### PR TITLE
[BugFix] Fix OfdDistiller when the names of bn modules are different between teacher and student

### DIFF
--- a/mmrazor/models/distillers/ofd_distiller.py
+++ b/mmrazor/models/distillers/ofd_distiller.py
@@ -32,20 +32,18 @@ class OFDDistiller(ConfigurableDistiller):
             if isinstance(self.distill_losses[loss_key], OFDLoss):
                 for _input_keys, _input_mapping in loss_forward_mapping.items(
                 ):
-                    recorder_mgn = self.student_recorders if _input_mapping[
-                        'from_student'] else self.teacher_recorders
-                    recorder = recorder_mgn.get_recorder(
-                        _input_mapping['recorder'])
-                    module_key = recorder.source
-                    bn_module = attrgetter(module_key)(teacher)
-
-                    assert isinstance(
-                        bn_module, (nn.BatchNorm2d, nn.SyncBatchNorm)), (
-                            'Overhaul distillation only support connection on '
-                            'layers: [`BatchNorm2d`, `SyncBatchNorm`]')
-
                     if 'connector' in _input_mapping and not _input_mapping[
                             'from_student']:
+
+                        recorder = self.teacher_recorders.get_recorder(
+                            _input_mapping['recorder'])
+                        module_key = recorder.source
+                        bn_module = attrgetter(module_key)(teacher)
+
+                        assert isinstance(
+                            bn_module, (nn.BatchNorm2d, nn.SyncBatchNorm)
+                        ), ('Overhaul distillation only support connection on '
+                            'layers: [`BatchNorm2d`, `SyncBatchNorm`]')
                         connector = self.connectors[
                             _input_mapping['connector']]
                         assert isinstance(connector, OFDTeacherConnector), (


### PR DESCRIPTION
Fix OfdDistiller when the names of bn modules are different between teacher and student

Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

It would fetch the name of student modules from teacher, this is not reasonable and cause exceptions if the names are not identical between student and teacher.

Also, we only need to do this if `from_student=False`, so i moved the code under the if condition.

## Modification

I moved the code under the if condition to fix the moudleName-notfound bug.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
