### PR TITLE
[Feature] Support lsq

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ concurrency:
 
 jobs:
   test_linux:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [3.7]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/timothycrosley/isort
-    rev: 5.10.1
+    rev: 5.11.5
     hooks:
       - id: isort
   - repo: https://github.com/pre-commit/mirrors-yapf

--- a/mmrazor/engine/runner/quantization_loops.py
+++ b/mmrazor/engine/runner/quantization_loops.py
@@ -87,7 +87,6 @@ class QATEpochBasedLoop(EpochBasedTrainLoop):
                     and self._epoch % self.val_interval == 0):
                 # observer disabled during evaluation
                 self.prepare_for_val()
-                self.runner.model.sync_qparams(src_mode='loss')
                 self.runner.val_loop.run()
 
         self.runner.call_hook('after_train')
@@ -108,6 +107,7 @@ class QATEpochBasedLoop(EpochBasedTrainLoop):
         for idx, data_batch in enumerate(self.dataloader):
             self.run_iter(idx, data_batch)
 
+        self.runner.model.sync_qparams(src_mode='loss')
         self.runner.call_hook('after_train_epoch')
         self._epoch += 1
 
@@ -181,6 +181,7 @@ class LSQEpochBasedLoop(QATEpochBasedLoop):
                 self.runner.model.apply(enable_param_learning)
             self.run_iter(idx, data_batch)
 
+        self.runner.model.sync_qparams(src_mode='loss')
         self.runner.call_hook('after_train_epoch')
         self._epoch += 1
 

--- a/mmrazor/models/algorithms/quantization/mm_architecture.py
+++ b/mmrazor/models/algorithms/quantization/mm_architecture.py
@@ -363,7 +363,7 @@ class MMArchitectureQuant(BaseAlgorithm):
         fp32_model = self.architecture
         self.quantizer.convert_batchnorm2d(fp32_model)
         observed_model = self.quantizer.prepare(fp32_model)
-        observed_model.load_state_dict(quantized_state_dict, strict=False)
+        observed_model.load_state_dict(quantized_state_dict)
 
         self.quantizer.post_process_for_deploy(
             observed_model,


### PR DESCRIPTION
# Modifications

1. Support deploy_cfg is None
2. Put `replace_fakequant` before 'load_state_dict` (for lsq)
3. Add `_load_from_state_dict` interface to lsq fakequant to fix the bug when loading ckpt in mmdeploy.
4. Add pytest
5. change github ci: ubuntu 18.04 to ubuntu 20.04
