### PR TITLE
[Fix] Estimate sub-model latency in the process of NAS

### DIFF
--- a/mmrazor/engine/runner/utils/check.py
+++ b/mmrazor/engine/runner/utils/check.py
@@ -34,10 +34,13 @@ def check_subnet_resources(
     _, sliced_model = export_fix_subnet(model, slice_weight=True)
 
     model_to_check = sliced_model.architecture  # type: ignore
+    measure_latency = True if 'latency' in constraints_range.keys() else False
     if isinstance(model_to_check, BaseDetector):
-        results = estimator.estimate(model=model_to_check.backbone, measure_latency=True if 'latency' in constraints_range.keys() else False)
+        results = estimator.estimate(model=model_to_check.backbone,
+                                     measure_latency=measure_latency)
     else:
-        results = estimator.estimate(model=model_to_check, measure_latency=True if 'latency' in constraints_range.keys() else False)
+        results = estimator.estimate(model=model_to_check,
+                                     measure_latency=measure_latency)
 
     for k, v in constraints_range.items():
         if not isinstance(v, (list, tuple)):

--- a/mmrazor/engine/runner/utils/check.py
+++ b/mmrazor/engine/runner/utils/check.py
@@ -35,9 +35,9 @@ def check_subnet_resources(
 
     model_to_check = sliced_model.architecture  # type: ignore
     if isinstance(model_to_check, BaseDetector):
-        results = estimator.estimate(model=model_to_check.backbone)
+        results = estimator.estimate(model=model_to_check.backbone, measure_latency=True if 'latency' in constraints_range.keys() else False)
     else:
-        results = estimator.estimate(model=model_to_check)
+        results = estimator.estimate(model=model_to_check, measure_latency=True if 'latency' in constraints_range.keys() else False)
 
     for k, v in constraints_range.items():
         if not isinstance(v, (list, tuple)):

--- a/mmrazor/models/task_modules/estimators/resource_estimator.py
+++ b/mmrazor/models/task_modules/estimators/resource_estimator.py
@@ -95,7 +95,8 @@ class ResourceEstimator(BaseEstimator):
     def estimate(self,
                  model: torch.nn.Module,
                  flops_params_cfg: dict = None,
-                 latency_cfg: dict = None) -> Dict[str, Union[float, str]]:
+                 latency_cfg: dict = None,
+                 measure_latency: bool = False) -> Dict[str, Union[float, str]]:
         """Estimate the resources(flops/params/latency) of the given model.
 
         This method will first parse the merged :attr:`self.flops_params_cfg`
@@ -106,6 +107,7 @@ class ResourceEstimator(BaseEstimator):
             flops_params_cfg (dict): Cfg for estimating FLOPs and parameters.
                 Default to None.
             latency_cfg (dict): Cfg for estimating latency. Default to None.
+            measure_latency (bool): Measure latency or not. Default to False.
 
             NOTE: If the `flops_params_cfg` and `latency_cfg` are both None,
             this method will only estimate FLOPs/params with default settings.

--- a/mmrazor/models/task_modules/estimators/resource_estimator.py
+++ b/mmrazor/models/task_modules/estimators/resource_estimator.py
@@ -92,12 +92,12 @@ class ResourceEstimator(BaseEstimator):
             self.flops_params_cfg = dict()
         self.latency_cfg = latency_cfg if latency_cfg else dict()
 
-    def estimate(self,
-                 model: torch.nn.Module,
-                 flops_params_cfg: dict = None,
-                 latency_cfg: dict = None,
-                 measure_latency: bool = False
-                 ) -> Dict[str, Union[float, str]]:
+    def estimate(
+            self,
+            model: torch.nn.Module,
+            flops_params_cfg: dict = None,
+            latency_cfg: dict = None,
+            measure_latency: bool = False) -> Dict[str, Union[float, str]]:
         """Estimate the resources(flops/params/latency) of the given model.
 
         This method will first parse the merged :attr:`self.flops_params_cfg`

--- a/mmrazor/models/task_modules/estimators/resource_estimator.py
+++ b/mmrazor/models/task_modules/estimators/resource_estimator.py
@@ -96,7 +96,8 @@ class ResourceEstimator(BaseEstimator):
                  model: torch.nn.Module,
                  flops_params_cfg: dict = None,
                  latency_cfg: dict = None,
-                 measure_latency: bool = False) -> Dict[str, Union[float, str]]:
+                 measure_latency: bool = False
+                 ) -> Dict[str, Union[float, str]]:
         """Estimate the resources(flops/params/latency) of the given model.
 
         This method will first parse the merged :attr:`self.flops_params_cfg`

--- a/mmrazor/models/task_modules/estimators/resource_estimator.py
+++ b/mmrazor/models/task_modules/estimators/resource_estimator.py
@@ -117,7 +117,6 @@ class ResourceEstimator(BaseEstimator):
                 results(FLOPs, params and latency).
         """
         resource_metrics = dict()
-        measure_latency = True if latency_cfg else False
 
         if flops_params_cfg:
             flops_params_cfg = {**self.flops_params_cfg, **flops_params_cfg}


### PR DESCRIPTION
## Motivation

I tried to add latency constrains in NAS (add `constraints_range=dict(latency=(0., 10.))` in dict `train_cfg` of `configs/nas/mmcls/spos/spos_mobilenet_search_8xb128_in1k.py`), but found there was no time measurement actually.

Through this PR, sub-model time measurement will be properly performed in NAS.

## Reason of bug

When we get sub-model informations as 'flops / params / latency' in `mmrazor/engine/runner/utils/check.py`, we need results from function `estimator.estimate`. However, variable `latency_cfg` is not provided to function `estimator.estimate`, and `latency_cfg` is default to None. Then `measure_latency` will be always False in `mmrazor/models/task_modules/estimators/resource_estimator.py` and no time measurement will be produced.

## Modification

Add Args `measure_latency` in function `estimator.estimate`. Make some code modification. 