### PR TITLE
Fix: CustomTracer originally failed to trace Tensor object

### DIFF
--- a/mmrazor/models/task_modules/tracer/fx/custom_tracer.py
+++ b/mmrazor/models/task_modules/tracer/fx/custom_tracer.py
@@ -142,6 +142,10 @@ def _prepare_module_dict(model: torch.nn.Module, fx_graph):
             if isinstance(attr, nn.Module):
                 module_dict[node.target] = nn.Module()
                 special_nodes.append(node)
+            #; the original design fails to 
+            #; trace any Tensor object
+            elif isinstance(attr, torch.Tensor):
+                module_dict[node.target] = attr
         elif node.op == 'call_method':
             for special_node in special_nodes:
                 if special_node in node.args or \


### PR DESCRIPTION
fix the problem that the static graph of a model fails to trace any tensor constants within.

## Motivation

During QAT training, the model being trained contains some tensor constants, such as `reg_max=torch.arange(16)`. These constants are also stored within the model. However, the following logic fails to include these tensors, resulting in a mismatch between the static graph and the actual model during subsequent training.

<img width="777" alt="image" src="https://github.com/user-attachments/assets/faecb13f-3623-4bcb-ae29-8c17a269aeb5">



## Modification

`elif` is added to support tensor objects, as shown in line 147 and 148

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories? 

**No**

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [❌] Pre-commit or other linting tools are used to fix the potential lint issues.
- [✅] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [✅] The modification is covered by complete unit tests. If not, please add more unit tests to ensure the correctness.
- [❌] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
